### PR TITLE
Added tooltips to model tools buttons

### DIFF
--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -120,6 +120,15 @@
   "go-to": "Go to",
   "graph": "Graph",
   "graph-settings": "Graph settings",
+  "graph-tools": {
+    "zoom-in": "Zoom in",
+    "zoom-out": "Zoom out",
+    "fullscreen": "Fullscreen",
+    "reset-positions": "Reset positions",
+    "zoom-to": "Zoom to",
+    "save-positions": "Save positions",
+    "download-picture": "Download picture"
+  },
   "highlight-class-association-restrictions": "Highlight class association restrictions",
   "highlight-class-associations": "Highlight class associations",
   "impersonate-user": "Impersonate user",

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -120,6 +120,15 @@
   "go-to": "Siirry",
   "graph": "Kaavio",
   "graph-settings": "Kaavion asetukset",
+  "graph-tools": {
+    "zoom-in": "Lähennä",
+    "zoom-out": "Loitonna",
+    "fullscreen": "Koko näyttö",
+    "reset-positions": "Palauta sijainnit",
+    "zoom-to": "Kohdenna",
+    "save-positions": "Tallenna sijainnit",
+    "download-picture": "Lataa kuvana"
+  },
   "highlight-class-association-restrictions": "Korosta luokkien assosiaatiorajoitteet",
   "highlight-class-associations": "Korosta luokkien assosiaatiot",
   "impersonate-user": "Esiinny käyttäjänä",

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -120,6 +120,15 @@
   "go-to": "",
   "graph": "",
   "graph-settings": "",
+  "graph-tools": {
+    "zoom-in": "",
+    "zoom-out": "",
+    "fullscreen": "",
+    "reset-positions": "",
+    "zoom-to": "",
+    "save-positions": "",
+    "download-picture": ""
+  },
   "highlight-class-association-restrictions": "",
   "highlight-class-associations": "",
   "impersonate-user": "",

--- a/datamodel-ui/src/common/components/model-tools/download-picture.tsx
+++ b/datamodel-ui/src/common/components/model-tools/download-picture.tsx
@@ -9,7 +9,13 @@ function downloadImg(dataUrl: string, fileName: string) {
   a.click();
 }
 
-export default function DownloadPicture({ modelId }: { modelId: string }) {
+export default function DownloadPicture({
+  modelId,
+  setRef,
+}: {
+  modelId: string;
+  setRef: (value: HTMLButtonElement | null) => void;
+}) {
   const { getNodes } = useReactFlow();
 
   const handleClick = () => {
@@ -44,5 +50,13 @@ export default function DownloadPicture({ modelId }: { modelId: string }) {
     }).then((dataUrl) => downloadImg(dataUrl, modelId));
   };
 
-  return <Button icon={<IconDownload />} onClick={() => handleClick()} />;
+  return (
+    <Button
+      id="graph-tools_download-picture"
+      icon={<IconDownload />}
+      onClick={() => handleClick()}
+      onMouseEnter={(ref) => setRef(ref.currentTarget)}
+      onMouseLeave={() => setRef(null)}
+    />
+  );
 }

--- a/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
+++ b/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
@@ -39,3 +39,23 @@ export const ToggleButtonGroup = styled.div`
     font-size: 16px;
   }
 `;
+
+export const TipTooltipWrapper = styled.div<{
+  $x?: number | null;
+  $y?: number | null;
+}>`
+  position: absolute;
+  right: 50px;
+  top: calc(${(props) => props.$y}px - 146px);
+
+  button {
+    visibility: hidden !important;
+    display: none !important;
+  }
+
+  .fi-tooltip_content {
+    padding: ${(props) =>
+      `${props.theme.suomifi.spacing.xxs} ${props.theme.suomifi.spacing.s}`};
+    white-space: nowrap;
+  }
+`;

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -512,3 +512,31 @@ export function translateNotification(
       return '';
   }
 }
+
+export function translateTooltip(key: string, t: TFunction) {
+  switch (key) {
+    case 'graph-tools_zoom-in':
+      return t('graph-tools.zoom-in', { ns: 'common' });
+      return 'Zoom in';
+    case 'graph-tools_zoom-out':
+      return t('graph-tools.zoom-out', { ns: 'common' });
+      return 'Zoom out';
+    case 'graph-tools_fullscreen':
+      return t('graph-tools.fullscreen', { ns: 'common' });
+      return 'Fullscreen';
+    case 'graph-tools_reset-positions':
+      return t('graph-tools.reset-positions', { ns: 'common' });
+      return 'Reset positions';
+    case 'graph-tools_zoom-to':
+      return t('graph-tools.zoom-to', { ns: 'common' });
+      return 'Zoom to';
+    case 'graph-tools_save-positions':
+      return t('graph-tools.save-positions', { ns: 'common' });
+      return 'Save positions';
+    case 'graph-tools_download-picture':
+      return t('graph-tools.download-picture', { ns: 'common' });
+      return 'Download picture';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
Changes in this PR:
- Added tooltip to graph tools buttons with small description texts on what each button does
- Tooltip is displayed when user hovers over the button for a second

![Screenshot from 2023-11-28 08-35-25](https://github.com/VRK-YTI/yti-terminology-ui/assets/82932696/23c715ac-efc1-4d9a-beb0-e6994f682aff)
