### PR TITLE
Disabled association target selection in class edit view

### DIFF
--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -761,6 +761,7 @@ export default function ClassForm({
                     classId={data.identifier}
                     applicationProfile={applicationProfile}
                     hasPermission
+                    disableAssocTarget={true}
                     handlePropertiesUpdate={() => {
                       const newAssociations = data.association
                         ? data.association.filter(

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -74,7 +74,7 @@ export default function ResourceInfo({
       modelId: data.modelId,
       resourceIdentifier: data.identifier,
       applicationProfile,
-      // version: data.version,
+      version: data.version,
     },
     { skip: !open }
   );

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -46,6 +46,7 @@ interface ResourceInfoProps {
   handlePropertiesUpdate: () => void;
   disableEdit?: boolean;
   targetInClassRestriction?: UriData;
+  disableAssocTarget?: boolean;
 }
 
 export default function ResourceInfo({
@@ -58,6 +59,7 @@ export default function ResourceInfo({
   handlePropertiesUpdate,
   disableEdit,
   targetInClassRestriction,
+  disableAssocTarget,
 }: ResourceInfoProps) {
   const { t, i18n } = useTranslation('common');
   const [open, setOpen] = useState(false);
@@ -72,7 +74,7 @@ export default function ResourceInfo({
       modelId: data.modelId,
       resourceIdentifier: data.identifier,
       applicationProfile,
-      version: data.version,
+      // version: data.version,
     },
     { skip: !open }
   );
@@ -200,6 +202,7 @@ export default function ResourceInfo({
             displayLabel
             inUse={!data.deactivated}
             applicationProfile={applicationProfile}
+            disableAssocTarget={disableAssocTarget}
             renderActions={renderActions}
             handleChangeTarget={handleChangeTarget}
           />

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -33,6 +33,7 @@ export default function CommonViewContent({
   data,
   displayLabel,
   applicationProfile,
+  disableAssocTarget = false,
   renderActions,
   handleChangeTarget,
 }: {
@@ -41,6 +42,7 @@ export default function CommonViewContent({
   data: Resource;
   displayLabel?: boolean;
   applicationProfile?: boolean;
+  disableAssocTarget?: boolean;
   renderActions?: () => void;
   handleChangeTarget?: (value?: InternalClassInfo) => void;
 }) {
@@ -401,7 +403,8 @@ export default function CommonViewContent({
           </>
         )}
 
-      {!applicationProfile &&
+      {!disableAssocTarget &&
+        !applicationProfile &&
         data.type === ResourceType.ASSOCIATION &&
         handleChangeTarget && (
           <>


### PR DESCRIPTION
Changes in this PR:
- Association target selection disabled in class edit view. This feature is still available in class information view