### PR TITLE
Datamodel yti 3704 hidden elements info

### DIFF
--- a/common-ui/components/drawer/drawer-content-wrapper.tsx
+++ b/common-ui/components/drawer/drawer-content-wrapper.tsx
@@ -8,7 +8,7 @@ const DrawerContentWrapper = styled.div<{ $height?: number }>`
   height: calc(100% - ${(props) => (props.$height ?? 0) + 30}px);
 
   padding: 15px;
-  padding-top: ${(props) => (props.$height ?? 0) + 15}px;
+  margin-top: ${(props) => props.$height ?? 0}px;
 
   .fullwidth {
     width: 100%;
@@ -33,8 +33,6 @@ const DrawerContentWrapper = styled.div<{ $height?: number }>`
   ::-webkit-scrollbar-thumb:hover {
     background: #6e6e6e;
   }
-
-  -webkit-transform: translate3d(0, 0, 0);
 `;
 
 interface DrawerContentProps {

--- a/datamodel-ui/next.config.js
+++ b/datamodel-ui/next.config.js
@@ -98,7 +98,7 @@ module.exports = () => {
           {
             source: '/terminology-api/:path*',
             destination:
-              'https://yhteentoimiva.test.dev.yti.cloud.dvv.fi/terminology-api/:path*',
+              'https://yhteentoimiva.test.yti.cloud.dvv.fi/terminology-api/:path*',
           },
           {
             source: '/codelist-api/:path*',

--- a/datamodel-ui/next.config.js
+++ b/datamodel-ui/next.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable quotes */
 const { i18n } = require('./next-i18next.config');
 
 module.exports = () => {
@@ -98,11 +99,12 @@ module.exports = () => {
           {
             source: '/terminology-api/:path*',
             destination:
-              'https://yhteentoimiva.test.yti.cloud.dvv.fi/terminology-api/:path*',
+              'https://sanastot.dev.yti.cloud.dvv.fi/terminology-api/:path*',
           },
           {
             source: '/codelist-api/:path*',
-            destination: 'https://koodistot.suomi.fi/codelist-api/:path*',
+            destination:
+              'https://koodistot.dev.yti.cloud.dvv.fi/codelist-api/:path*',
           },
           {
             source: '/messaging-api/:path*',

--- a/datamodel-ui/next.config.js
+++ b/datamodel-ui/next.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 const { i18n } = require('./next-i18next.config');
 
 module.exports = () => {
@@ -99,12 +98,11 @@ module.exports = () => {
           {
             source: '/terminology-api/:path*',
             destination:
-              'https://sanastot.dev.yti.cloud.dvv.fi/terminology-api/:path*',
+              'https://yhteentoimiva.test.dev.yti.cloud.dvv.fi/terminology-api/:path*',
           },
           {
             source: '/codelist-api/:path*',
-            destination:
-              'https://koodistot.dev.yti.cloud.dvv.fi/codelist-api/:path*',
+            destination: 'https://koodistot.suomi.fi/codelist-api/:path*',
           },
           {
             source: '/messaging-api/:path*',

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -2,7 +2,7 @@ import { StatusChip } from '@app/common/components/resource-list/resource-list.s
 import { ClassType } from '@app/common/interfaces/class.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { useTranslation } from 'next-i18next';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Button,
   ExpanderGroup,
@@ -78,7 +78,6 @@ export default function ClassInfo({
     actions: ['EDIT_CLASS'],
     targetOrganization: organizationIds,
   });
-  const ref = useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState(hasPermission ? 57 : 55);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showRenameModal, setShowRenameModal] = useState(false);
@@ -117,12 +116,6 @@ export default function ClassInfo({
       dispatch(setAddResourceRestrictionToClass(true));
     }
   };
-
-  useEffect(() => {
-    if (ref.current) {
-      setHeaderHeight(ref.current.clientHeight);
-    }
-  }, [data]);
 
   function renderTopInfoByType() {
     if (!data) {
@@ -217,7 +210,11 @@ export default function ClassInfo({
 
   return (
     <>
-      <StaticHeader ref={ref}>
+      <StaticHeader
+        ref={(node) => {
+          setHeaderHeight(node?.clientHeight ?? 50);
+        }}
+      >
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Button
             variant="secondaryNoBorder"
@@ -264,6 +261,19 @@ export default function ClassInfo({
               hide={() => setShowRenameModal(false)}
               handleReturn={handleShowClass}
             />
+            <div
+              style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}
+            >
+              <Text variant="bold">
+                {getLanguageVersion({
+                  data: data.label,
+                  lang: displayLang ?? i18n.language,
+                })}
+              </Text>
+              <StatusChip status={data.status}>
+                {translateStatus(data.status, t)}
+              </StatusChip>
+            </div>
           </>
         ) : (
           <></>
@@ -279,18 +289,6 @@ export default function ClassInfo({
           ) : (
             <></>
           )}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-            <Text variant="bold">
-              {getLanguageVersion({
-                data: data.label,
-                lang: displayLang ?? i18n.language,
-              })}
-            </Text>
-            <StatusChip status={data.status}>
-              {translateStatus(data.status, t)}
-            </StatusChip>
-          </div>
-
           <BasicBlock title={t('class-identifier')}>{data.curie}</BasicBlock>
 
           <BasicBlock title={t('uri')}>

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -6,7 +6,7 @@ import {
   translateStatus,
 } from '@app/common/utils/translation-helpers';
 import { useTranslation } from 'next-i18next';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActionMenu,
   ActionMenuDivider,
@@ -60,7 +60,6 @@ export default function ResourceInfo({
   organizationIds,
 }: CommonViewProps) {
   const { t, i18n } = useTranslation('common');
-  const ref = useRef<HTMLDivElement>(null);
   const displayLang = useSelector(selectDisplayLang());
   const hasPermission = HasPermission({
     actions: ['EDIT_ASSOCIATION', 'EDIT_ATTRIBUTE'],
@@ -96,15 +95,13 @@ export default function ResourceInfo({
     }
   }, [toggleResult, handleRefetch]);
 
-  useEffect(() => {
-    if (ref.current) {
-      setHeaderHeight(ref.current.clientHeight);
-    }
-  }, [ref]);
-
   return (
     <>
-      <StaticHeader ref={ref}>
+      <StaticHeader
+        ref={(node) => {
+          setHeaderHeight(node?.clientHeight ?? 50);
+        }}
+      >
         <div>
           <Button
             variant="secondaryNoBorder"


### PR DESCRIPTION
Changelog:
- Use ref callback instead of ref, this makes ref update properly.
- use margin-top instead of padding-top so that the scrollbar is not unnecessarily hidden
- remove unneeded translate3d css rule
- make class info view also have a the title as a static header