### PR TITLE
YTI-3664: add to draft button

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -313,6 +313,7 @@
   "terminology": "Terminology",
   "terminology-counts_one": "{{count}} terminology",
   "terminology-counts_other": "{{count}} terminologies",
+  "to-draft": "Go to draft version",
   "try-again": "Try again",
   "unexpected-error-title": "Unexpected error",
   "updated": "Updated",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -313,6 +313,7 @@
   "terminology": "Sanasto",
   "terminology-counts_one": "{{count}} sanasto",
   "terminology-counts_other": "{{count}} sanastoa",
+  "to-draft": "Siirry luonnosversioon",
   "try-again": "Yritä uudelleen",
   "unexpected-error-title": "Odottamaton virhe",
   "updated": "Päivitetty",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -313,6 +313,7 @@
   "terminology": "",
   "terminology-counts_one": "",
   "terminology-counts_other": "",
+  "to-draft": "",
   "try-again": "",
   "unexpected-error-title": "",
   "updated": "",

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -50,6 +50,7 @@ export default function ModelInfoView({
   organizationIds?: string[];
 }) {
   const { t, i18n } = useTranslation('common');
+  const router = useRouter();
   const dispatch = useStoreDispatch();
   const { query } = useRouter();
   const [modelId] = useState(getSlugAsString(query.slug) ?? '');
@@ -168,29 +169,34 @@ export default function ModelInfoView({
           <Text variant="bold">{t('details')}</Text>
           <ActionMenu id="actions-menu" buttonText={t('actions')}>
             {hasPermission ? (
-              <>
-                <ActionMenuItem
-                  onClick={() => handleEditViewItemClick(setShowEditView)}
-                  disabled={!formData}
-                >
-                  {t('edit', { ns: 'admin' })}
-                </ActionMenuItem>
-                <ActionMenuDivider />
-              </>
-            ) : (
-              <></>
-            )}
-            {hasPermission && !version ? (
               <ActionMenuItem
-                onClick={() => handleModalChange('createRelease', true)}
+                onClick={() => handleEditViewItemClick(setShowEditView)}
                 disabled={!formData}
               >
-                {t('create-release', { ns: 'admin' })}
+                {t('edit', { ns: 'admin' })}
               </ActionMenuItem>
             ) : (
               <></>
             )}
-
+            {hasPermission ? (
+              version ? (
+                <ActionMenuItem
+                  onClick={() => router.push(`/model/${modelId}`)}
+                >
+                  {t('to-draft', { ns: 'admin' })}
+                </ActionMenuItem>
+              ) : (
+                <ActionMenuItem
+                  onClick={() => handleModalChange('createRelease', true)}
+                  disabled={!formData}
+                >
+                  {t('create-release', { ns: 'admin' })}
+                </ActionMenuItem>
+              )
+            ) : (
+              <></>
+            )}
+            {hasPermission ? <ActionMenuDivider /> : <></>}
             <ActionMenuItem
               onClick={() => handleModalChange('showAsFile', true)}
             >


### PR DESCRIPTION
Changelog: 
- To draft button
- The conditional rendering was done like this with separate checks for each component because the ActionMenu component requires ActionMenuItem to be a direct child for the highlighting to work.  Conditional rendering introduces the react fragment which makes it so that if multiple items are rendered under the same condition then they will not be direct children anymore