### PR TITLE
Fixed incorrect format of asPath

### DIFF
--- a/common-ui/components/authentication-panel/user-info.tsx
+++ b/common-ui/components/authentication-panel/user-info.tsx
@@ -21,7 +21,11 @@ export default function UserInfo({ breakpoint, user }: UserInfoProps) {
   return (
     <UserInfoWrapper $breakpoint={breakpoint} id="login-information">
       <Text>{`${user?.firstName} ${user?.lastName}`}</Text>
-      <Link href={`/api/auth/logout?target=/${i18n.language ?? 'fi'}${asPath}`}>
+      <Link
+        href={`/api/auth/logout?target=/${
+          i18n.language ?? 'fi'
+        }${encodeURIComponent(asPath)}`}
+      >
         {t('site-logout')}
       </Link>
     </UserInfoWrapper>


### PR DESCRIPTION
Changes in this PR:
- Fixed uri changing when logging out
- This fixes the bug in both Terminologies and Data models 
- If `asPath` is passed as is the object type changes so that it passes parameters to own values under new keys. Passing it through `encodeURIComponent` keeps the value as we want