### PR TITLE
YTI-3703: show child orgs and hide deleted orgs

### DIFF
--- a/common-ui/modules/own-information/index.tsx
+++ b/common-ui/modules/own-information/index.tsx
@@ -116,34 +116,38 @@ export default function OwnInformation({
           id="organizations-and-roles"
         >
           <OrgsAndRolesWrapper>
-            {Object.entries(user.rolesInOrganizations).map((data) => (
-              <div key={data[0]}>
-                <BasicBlock title={t('organization')}>
-                  {organizations
-                    ? getLanguageVersion({
-                        data: organizations.find((org) => org.id === data[0])
-                          ?.label,
-                        lang: i18n.language,
-                        appendLocale: true,
-                      })
-                    : null}
-                </BasicBlock>
+            {Object.entries(user.rolesInOrganizations)
+              .filter((data) =>
+                organizations?.some((org) => org.id === data[0])
+              )
+              .map((data) => (
+                <div key={data[0]}>
+                  <BasicBlock title={t('organization')}>
+                    {organizations
+                      ? getLanguageVersion({
+                          data: organizations.find((org) => org.id === data[0])
+                            ?.label,
+                          lang: i18n.language,
+                          appendLocale: true,
+                        })
+                      : null}
+                  </BasicBlock>
 
-                <BasicBlock title={t('roles.roles')}>
-                  <OrgsAndRolesUl>
-                    {data[1].map((role) => (
-                      <li key={`${data[0]}-role-${role}`}>
-                        {translateRole(role, t)}
-                      </li>
-                    ))}
-                  </OrgsAndRolesUl>
-                </BasicBlock>
+                  <BasicBlock title={t('roles.roles')}>
+                    <OrgsAndRolesUl>
+                      {data[1].map((role) => (
+                        <li key={`${data[0]}-role-${role}`}>
+                          {translateRole(role, t)}
+                        </li>
+                      ))}
+                    </OrgsAndRolesUl>
+                  </BasicBlock>
 
-                {hasRequestPending(data[0]) && (
-                  <InlineAlert>{t('access-request-sent')}</InlineAlert>
-                )}
-              </div>
-            ))}
+                  {hasRequestPending(data[0]) && (
+                    <InlineAlert>{t('access-request-sent')}</InlineAlert>
+                  )}
+                </div>
+              ))}
           </OrgsAndRolesWrapper>
         </BasicBlock>
 

--- a/datamodel-ui/src/common/components/organizations/organizations.slice.tsx
+++ b/datamodel-ui/src/common/components/organizations/organizations.slice.tsx
@@ -7,9 +7,16 @@ export const organizationsApi = createApi({
   baseQuery: getDatamodelApiBaseQuery(),
   tagTypes: ['Organizations'],
   endpoints: (builder) => ({
-    getOrganizations: builder.query<Organization[], string>({
+    getOrganizations: builder.query<
+      Organization[],
+      { sortLang: string; includeChildOrganizations?: boolean }
+    >({
       query: (value) => ({
-        url: `/frontend/organizations?sortLang=${value}`,
+        url: `/frontend/organizations?sortLang=${value.sortLang}${
+          value.includeChildOrganizations
+            ? '&includeChildOrganizations=true'
+            : ''
+        }`,
         method: 'GET',
       }),
     }),

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -43,7 +43,9 @@ export default function FrontPage() {
   const { data: serviceCategoriesData } = useGetServiceCategoriesQuery(
     i18n.language
   );
-  const { data: organizationsData } = useGetOrganizationsQuery(i18n.language);
+  const { data: organizationsData } = useGetOrganizationsQuery({
+    sortLang: i18n.language,
+  });
   const { data: languagesData } = useGetLanguagesQuery();
   const { data: counts } = useGetCountQuery(initialUrlState);
   const { data: searchModels } = useGetSearchModelsQuery({

--- a/datamodel-ui/src/modules/model-form/index.tsx
+++ b/datamodel-ui/src/modules/model-form/index.tsx
@@ -60,7 +60,9 @@ export default function ModelForm({
   const { data: serviceCategoriesData } = useGetServiceCategoriesQuery(
     i18n.language
   );
-  const { data: organizationsData } = useGetOrganizationsQuery(i18n.language);
+  const { data: organizationsData } = useGetOrganizationsQuery({
+    sortLang: i18n.language,
+  });
   const { data: languages, isSuccess } = useGetLanguagesQuery();
   const [languageList, setLanguageList] = useState<LanguageBlockType[]>([]);
 

--- a/datamodel-ui/src/modules/own-information/index.tsx
+++ b/datamodel-ui/src/modules/own-information/index.tsx
@@ -20,7 +20,10 @@ import PermissionModal from 'yti-common-ui/modules/own-information/permission-mo
 export default function OwnInformation() {
   const user = useSelector(selectLogin());
   const { i18n } = useTranslation('common');
-  const { data: organizations } = useGetOrganizationsQuery(i18n.language);
+  const { data: organizations } = useGetOrganizationsQuery({
+    sortLang: i18n.language,
+    includeChildOrganizations: true,
+  });
   const { data: subscriptions, refetch: refetchSubscriptions } =
     useGetSubscriptionsQuery();
   const { data: requests, refetch: refetchRequests } = useGetRequestsQuery();

--- a/datamodel-ui/src/pages/index.tsx
+++ b/datamodel-ui/src/pages/index.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     }
 
     store.dispatch(getServiceCategories.initiate(locale ?? 'fi'));
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(getOrganizations.initiate({ sortLang: locale ?? 'fi' }));
     store.dispatch(
       getSearchModels.initiate({ urlState, lang: locale ?? 'fi' })
     );

--- a/datamodel-ui/src/pages/model/[...slug].tsx
+++ b/datamodel-ui/src/pages/model/[...slug].tsx
@@ -113,7 +113,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     store.dispatch(getAuthenticatedUser.initiate());
     store.dispatch(getModel.initiate({ modelId: modelId, version: version }));
     store.dispatch(getServiceCategories.initiate(locale ?? 'fi'));
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(getOrganizations.initiate({ sortLang: locale ?? 'fi' }));
     store.dispatch(
       queryInternalResources.initiate({
         query: '',

--- a/datamodel-ui/src/pages/own-information.tsx
+++ b/datamodel-ui/src/pages/own-information.tsx
@@ -40,7 +40,7 @@ export default function OwnInformationPage(props: OwnInformationPageProps) {
 
 export const getServerSideProps = createCommonGetServerSideProps(
   async ({ store, locale }) => {
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(getOrganizations.initiate({ sortLang: locale ?? 'fi' }));
     store.dispatch(getSubscriptions.initiate());
     store.dispatch(getRequests.initiate());
 


### PR DESCRIPTION
changelog:
 - Get child organisations when getting organisations from backend
 - Hide all organisations that do not have a label. All organisations have a label when getting them so this basically filters out only deleted organisations