### PR TITLE
YTI-3688 increase documentation max character count

### DIFF
--- a/datamodel-ui/src/modules/documentation/index.tsx
+++ b/datamodel-ui/src/modules/documentation/index.tsx
@@ -493,7 +493,7 @@ export default function Documentation({
                 />
               </div>
               <HintText>
-                {value[currentLanguage]?.length ?? 0} / 5000 {t('characters')}
+                {value[currentLanguage]?.length ?? 0} / 50000 {t('characters')}
               </HintText>
             </ControlsRow>
 


### PR DESCRIPTION
In the old data there are some very long documentations. Increase max character count to 50000. Backend changes in this PR https://github.com/VRK-YTI/yti-datamodel-api/pull/261