### PR TITLE
YTI-3678: resource search frontpage

### DIFF
--- a/common-ui/components/search-results/result-card-typed-expander.tsx
+++ b/common-ui/components/search-results/result-card-typed-expander.tsx
@@ -1,0 +1,130 @@
+import { useTranslation } from 'next-i18next';
+import Link from 'next/link';
+import {
+  Expander,
+  ExpanderContent,
+  ExpanderTitleButton,
+  Link as SuomiFiLink,
+} from 'suomifi-ui-components';
+import SanitizedTextContent from '../sanitized-text-content';
+import {
+  ExpanderContentTitle,
+  ExpanderTitleHits,
+  HitsWrapper,
+} from './result-card-expander.styles';
+import styled from 'styled-components';
+
+const TypedExpanderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+interface ResultCardTypedExpanderProps {
+  deepHits: {
+    type: string;
+    label: string;
+    id: string;
+    uri?: string;
+  }[];
+  typeLabels: { [key: string]: string };
+  buttonLabel: string;
+}
+
+export default function ResultCardTypedExpander({
+  deepHits,
+  buttonLabel,
+  typeLabels,
+}: ResultCardTypedExpanderProps) {
+  const { t } = useTranslation();
+  const suffix = deepHits.length > 3 ? true : false;
+
+  return (
+    <Expander id="search-result-expander">
+      <ExpanderTitleButton>
+        Tuloksia hakusanalla
+        <ExpanderTitleHits>
+          {suffix ? renderHitsWithSuffix() : renderHits()}
+        </ExpanderTitleHits>
+      </ExpanderTitleButton>
+      <ExpanderContent>
+        <HitsWrapper>{renderHitsInContent()}</HitsWrapper>
+      </ExpanderContent>
+    </Expander>
+  );
+
+  function renderHits() {
+    const totalHits = deepHits.length;
+
+    return deepHits.map((hit, idx) => {
+      const comma = idx < 2 && idx < totalHits - 1 ? ', ' : '';
+
+      return (
+        <span key={`${hit.id}-${idx}`}>
+          <SanitizedTextContent text={`${hit.label} (${hit.type})`} />
+          {comma}
+        </span>
+      );
+    });
+  }
+
+  function renderHitsWithSuffix() {
+    return deepHits
+      .filter((_, idx) => idx < 3)
+      .map((hit, idx) => {
+        const comma =
+          idx < 2
+            ? ', '
+            : ` + ${deepHits.length - 1 - idx} ${t('vocabulary-results-more')}`;
+
+        return (
+          <span key={`${hit.id}-${idx}`}>
+            <SanitizedTextContent text={`${hit.label} (${hit.type})`} />
+            {comma}
+          </span>
+        );
+      });
+  }
+
+  function renderHitsInContent() {
+    return (
+      <TypedExpanderWrapper>
+        {Object.keys(typeLabels)
+          .filter((type) => deepHits.some((hit) => hit.type === type))
+          .map((type) => (
+            <div key="type">
+              <ExpanderContentTitle variant="h4">
+                {typeLabels[type]}
+              </ExpanderContentTitle>
+              <div style={{ display: 'flex', gap: '15px' }}>
+                {deepHits
+                  .filter((hit) => hit.type == type)
+                  .map((hit, idx) => {
+                    if (hit.uri) {
+                      return (
+                        <Link
+                          key={`${hit.id}-${idx}`}
+                          href={hit.uri}
+                          passHref
+                          legacyBehavior
+                        >
+                          <SuomiFiLink href="">
+                            <SanitizedTextContent text={hit.label} />
+                          </SuomiFiLink>
+                        </Link>
+                      );
+                    } else {
+                      return (
+                        <SanitizedTextContent
+                          text={hit.label}
+                          key={`${hit.id}-${idx}`}
+                        />
+                      );
+                    }
+                  })}
+              </div>
+            </div>
+          ))}
+      </TypedExpanderWrapper>
+    );
+  }
+}

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -5,6 +5,7 @@ import ResultCard from './result-card';
 import ResultCardExpander from './result-card-expander';
 import SanitizedTextContent from '../sanitized-text-content';
 import { ReactNode } from 'react';
+import ResultCardTypedExpander from './result-card-typed-expander';
 
 export interface SearchResultData {
   id: string;
@@ -62,6 +63,20 @@ interface SearchResultsProps {
             [key: string]: string;
           };
         };
+      }
+    | {
+        typedExpander: {
+          buttonLabel: string;
+          typeLabels: { [key: string]: string };
+          deepHits: {
+            [key: string]: {
+              type: string;
+              label: string;
+              id: string;
+              uri?: string;
+            }[];
+          };
+        };
       };
 }
 
@@ -83,6 +98,38 @@ export default function SearchResults({
 
   if (!data) {
     return null;
+  }
+
+  function renderExtra(id: string) {
+    if (!extra || !id) {
+      return;
+    }
+
+    if ('expander' in extra && extra.expander.deepHits[id]) {
+      return (
+        <ResultCardExpander
+          buttonLabel={extra.expander.buttonLabel}
+          contentLabel={extra.expander.contentLabel}
+          deepHits={extra.expander.deepHits[id]}
+        />
+      );
+    } else if ('typedExpander' in extra && extra.typedExpander.deepHits[id]) {
+      return (
+        <ResultCardTypedExpander
+          buttonLabel={extra.typedExpander.buttonLabel}
+          deepHits={extra.typedExpander.deepHits[id]}
+          typeLabels={extra.typedExpander.typeLabels}
+        />
+      );
+    } else if ('other' in extra) {
+      return (
+        <>
+          <CardConcepts value={extra.other.title}>
+            <SanitizedTextContent text={extra.other.items[id]} />
+          </CardConcepts>
+        </>
+      );
+    }
   }
 
   return (
@@ -114,26 +161,7 @@ export default function SearchResults({
               noDescriptionText={noDescriptionText}
               noChip={noChip}
               noVersion={noVersion}
-              extra={
-                extra &&
-                ('expander' in extra
-                  ? extra.expander.deepHits[d.id] && (
-                      <ResultCardExpander
-                        buttonLabel={extra.expander.buttonLabel}
-                        contentLabel={extra.expander.contentLabel}
-                        deepHits={extra.expander.deepHits[d.id]}
-                      />
-                    )
-                  : extra.other.items[d.id] && (
-                      <>
-                        <CardConcepts value={extra.other.title}>
-                          <SanitizedTextContent
-                            text={extra.other.items[d.id]}
-                          />
-                        </CardConcepts>
-                      </>
-                    ))
-              }
+              extra={renderExtra(d.id)}
             />
           );
         })}

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -6,6 +6,7 @@ import ResultCardExpander from './result-card-expander';
 import SanitizedTextContent from '../sanitized-text-content';
 import { ReactNode } from 'react';
 import ResultCardTypedExpander from './result-card-typed-expander';
+import { TFunction } from 'next-i18next';
 
 export interface SearchResultData {
   id: string;
@@ -66,14 +67,14 @@ interface SearchResultsProps {
       }
     | {
         typedExpander: {
-          buttonLabel: string;
-          typeLabels: { [key: string]: string };
+          translateResultType: (type: string, t: TFunction) => string;
+          translateGroupType: (type: string, t: TFunction) => string;
           deepHits: {
             [key: string]: {
               type: string;
               label: string;
               id: string;
-              uri?: string;
+              uri: string;
             }[];
           };
         };
@@ -116,9 +117,9 @@ export default function SearchResults({
     } else if ('typedExpander' in extra && extra.typedExpander.deepHits[id]) {
       return (
         <ResultCardTypedExpander
-          buttonLabel={extra.typedExpander.buttonLabel}
+          translateGroupType={extra.typedExpander.translateGroupType}
+          translateResultType={extra.typedExpander.translateResultType}
           deepHits={extra.typedExpander.deepHits[id]}
-          typeLabels={extra.typedExpander.typeLabels}
         />
       );
     } else if ('other' in extra) {

--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -211,6 +211,7 @@
   "return-to-association-list": "To association list",
   "return-to-attribute-list": "To attribute list",
   "return-to-class-list": "To class list",
+  "results-with-query": "Results with query",
   "roles": {
     "admin": "Admin",
     "code-list-editor": "Code list editor",

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -211,6 +211,7 @@
   "return-to-association-list": "Assosiaatio-listaan",
   "return-to-attribute-list": "Attribuutti-listaan",
   "return-to-class-list": "Luokka-listaan",
+  "results-with-query": "Tuloksia hakusanalla",
   "roles": {
     "admin": "Ylläpitäjä",
     "code-list-editor": "Koodistotyöntekijä",

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -211,6 +211,7 @@
   "return-to-association-list": "",
   "return-to-attribute-list": "",
   "return-to-class-list": "",
+  "results-with-query": "",
   "roles": {
     "admin": "",
     "code-list-editor": "",

--- a/datamodel-ui/src/common/interfaces/datamodel.interface.ts
+++ b/datamodel-ui/src/common/interfaces/datamodel.interface.ts
@@ -24,4 +24,13 @@ export interface DataModel {
   version?: string;
   versionIri?: string;
   uri: string;
+  matchingResources: {
+    id: string;
+    uri: string;
+    label: {
+      [key: string]: string;
+    };
+    resourceType: string;
+    [key: string]: unknown;
+  }[];
 }

--- a/datamodel-ui/src/common/interfaces/datamodel.interface.ts
+++ b/datamodel-ui/src/common/interfaces/datamodel.interface.ts
@@ -31,6 +31,9 @@ export interface DataModel {
       [key: string]: string;
     };
     resourceType: string;
+    highlights: {
+      [key: string]: string[];
+    };
     [key: string]: unknown;
   }[];
 }

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -683,3 +683,16 @@ export function translateDocumentationTooltip(key: string, t: TFunction) {
       return '';
   }
 }
+
+export function translateResultType(key: string, t: TFunction) {
+  switch (key) {
+    case 'class':
+      return t('classes', { ns: 'common' });
+    case 'attribute':
+      return t('attributes', { ns: 'common' });
+    case 'association':
+      return t('associations', { ns: 'common' });
+    default:
+      return '';
+  }
+}

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -14,12 +14,17 @@ export function translateModelType(type: Type, t: TFunction) {
   }
 }
 
-export function translateResourceType(type: ResourceType, t: TFunction) {
+export function translateResourceType(
+  type: ResourceType | string,
+  t: TFunction
+) {
   switch (type) {
     case ResourceType.ASSOCIATION:
-      return t('association', { ns: 'common' });
+    case 'association':
+      return t('association');
     case ResourceType.ATTRIBUTE:
-      return t('attribute', { ns: 'common' });
+    case 'attribute':
+      return t('attribute');
     default:
       return t('class', { ns: 'common' });
   }

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -30,7 +30,11 @@ import {
   TitleDescriptionWrapper,
 } from 'yti-common-ui/title/title.styles';
 import Pagination from 'yti-common-ui/pagination';
-import { translateModelType } from '@app/common/utils/translation-helpers';
+import {
+  translateModelType,
+  translateResourceType,
+  translateResultType,
+} from '@app/common/utils/translation-helpers';
 import ModelFormModal from '../model-form/model-form-modal';
 import { useGetLanguagesQuery } from '@app/common/components/code/code.slice';
 import { useGetCountQuery } from '@app/common/components/counts/counts.slice';
@@ -241,12 +245,8 @@ export default function FrontPage() {
             withDefaultStatuses={inUseStatusList}
             extra={{
               typedExpander: {
-                buttonLabel: 'Button label',
-                typeLabels: {
-                  attribute: t('attributes'),
-                  class: t('classes'),
-                  association: t('associations'),
-                },
+                translateResultType: translateResourceType,
+                translateGroupType: translateResultType,
                 deepHits: {
                   'https://iri.suomi.fi/model/all_models/1.0.0/': [
                     {
@@ -265,11 +265,13 @@ export default function FrontPage() {
                       type: 'attribute',
                       label: 'test 3',
                       id: 'id-3',
+                      uri: 'testuri',
                     },
                     {
                       type: 'attribute',
                       label: 'test 4',
                       id: 'id-4',
+                      uri: 'testuri',
                     },
                   ],
                 },

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -239,6 +239,42 @@ export default function FrontPage() {
               count: searchModels?.totalHitCount ?? 0,
             })}
             withDefaultStatuses={inUseStatusList}
+            extra={{
+              typedExpander: {
+                buttonLabel: 'Button label',
+                typeLabels: {
+                  attribute: t('attributes'),
+                  class: t('classes'),
+                  association: t('associations'),
+                },
+                deepHits: {
+                  'https://iri.suomi.fi/model/all_models/1.0.0/': [
+                    {
+                      type: 'class',
+                      label: 'test',
+                      id: 'id',
+                      uri: 'testuri',
+                    },
+                    {
+                      type: 'class',
+                      label: 'test 2',
+                      id: 'id-2',
+                      uri: 'testuri',
+                    },
+                    {
+                      type: 'attribute',
+                      label: 'test 3',
+                      id: 'id-3',
+                    },
+                    {
+                      type: 'attribute',
+                      label: 'test 4',
+                      id: 'id-4',
+                    },
+                  ],
+                },
+              },
+            }}
           />
           <Pagination
             maxPages={Math.ceil((searchModels?.totalHitCount ?? 1) / 50)}

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -124,7 +124,7 @@ export default function FrontPage() {
     }
   ] = useMemo(() => {
     if (!searchModels || !organizationsData || !serviceCategoriesData) {
-      return [];
+      return [[], {}];
     }
 
     const modelResults = searchModels.responseObjects.map((object) => {

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -184,7 +184,10 @@ export default function FrontPage() {
         });
         return {
           type: resource.resourceType,
-          label: label,
+          label:
+            resource.highlights['label.fi.keyword']?.[0] ||
+            resource.highlights['label.fi']?.[0] ||
+            label,
           id: resource.id,
           uri: resource.uri,
         };

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -176,7 +176,7 @@ export default function FrontPage() {
       [key: string]: { type: string; label: string; id: string; uri: string }[];
     } = {};
     searchModels.responseObjects.forEach((object) => {
-      extra[object.id] = object.matchingResources.map((resource) => {
+      const resources = object.matchingResources.map((resource) => {
         const label = getLanguageVersion({
           data: resource.label,
           lang: i18n.language,
@@ -189,6 +189,9 @@ export default function FrontPage() {
           uri: resource.uri,
         };
       });
+      if (resources.length > 0) {
+        extra[object.id] = resources;
+      }
     });
 
     return [modelResults, extra];


### PR DESCRIPTION
Changelod: 
- Add a new type of `extra` resultcard.

```ts
   interface TypedExander {
     deepHits: {
          [key: string]: {
            type: string;
            label: string;
            id: string;
            uri: string;
          }[];
        };
     translateResultType: (type: string, t: TFunction) => string;
     translateGroupType: (type: string, t: TFunction) => string;  
}
```

- Deep hits are a map of objects where key is the `versionIri` of a modle and the list of objects are resources that made deep hits
- TranslateResultType is a translate helper function that translates a result type ('class' --> 'Luokka')
- TranslateGroupType is a translate helper function that translates a groiup type ('class' --> 'Luokat')


Results will need to be mapped to this type.so that they can be used.
There is an example in `datamodel-ui/src/modules/front-page/index.tsx` on line 246

![image](https://github.com/VRK-YTI/yti-ui/assets/19401683/c67ac7be-4068-45aa-af3d-48b829135dfa)
