### PR TITLE
YTI-3285 Fix permission checks

### DIFF
--- a/datamodel-ui/src/common/utils/has-permission.tsx
+++ b/datamodel-ui/src/common/utils/has-permission.tsx
@@ -100,11 +100,6 @@ export function checkPermission({
     return true;
   }
 
-  // Return true if target organization is undefined and user has admin role
-  if (rolesInOrganizations.includes('ADMIN') && !targetOrganizations) {
-    return true;
-  }
-
   // Return true if user has admin role in target organization
   if (
     rolesInOrganizations.includes('ADMIN') &&
@@ -113,10 +108,13 @@ export function checkPermission({
     return true;
   }
 
+  // Actions not related to any organization
   if (
     (!targetOrganizations || targetOrganizations.length === 0) &&
-    rolesInOrganizations.includes('DATA_MODEL_EDITOR') &&
-    !actions.some((action) => action.includes('ADMIN'))
+    rolesInOrganizations.some((role) =>
+      ['DATA_MODEL_EDITOR', 'ADMIN'].includes(role)
+    ) &&
+    actions.includes('CREATE_DATA_MODEL')
   ) {
     return true;
   }

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -53,7 +53,7 @@ export default function CommonViewContent({
 }) {
   const { t, i18n } = useTranslation('common');
   const hasPermission = HasPermission({
-    actions: ['ADMIN_ASSOCIATION', 'ADMIN_ATTRIBUTE'],
+    actions: ['EDIT_ASSOCIATION', 'EDIT_ATTRIBUTE'],
   });
   const displayLang = useSelector(selectDisplayLang());
   const { data: codesResult } = useGetAllCodesQuery(

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -281,7 +281,7 @@ const GraphContent = ({
       if (
         checkPermission({
           user: user,
-          actions: ['ADMIN_DATA_MODEL'],
+          actions: ['EDIT_DATA_MODEL'],
           targetOrganizations: organizationIds,
         }) &&
         node.dragging

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -65,6 +65,9 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
   }, [modelInfo]);
 
   const views: ViewType[] = useMemo(() => {
+    if (!modelInfo) {
+      return [];
+    }
     return [
       {
         id: 'search',


### PR DESCRIPTION
- Check that model data has been loaded before rendering view (and check permissions)
- Add separate check for action not related to any organization, at the moment only CREATE_DATA_MODEL
- Fix permissions for showing internal comments and positions changed -indicator. These don't require admin privileges, but allowed also for datamodel editors