### PR TITLE
use versioned internal urls for resource matches in search

### DIFF
--- a/datamodel-ui/src/common/interfaces/datamodel.interface.ts
+++ b/datamodel-ui/src/common/interfaces/datamodel.interface.ts
@@ -34,6 +34,7 @@ export interface DataModel {
     highlights: {
       [key: string]: string[];
     };
+    curie: string;
     [key: string]: unknown;
   }[];
 }

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -182,6 +182,15 @@ export default function FrontPage() {
           lang: i18n.language,
           appendLocale: true,
         });
+
+        const modelId = resource.curie.split(':')[0];
+        const versionPart = resource.fromVersion
+          ? `?ver=${resource.fromVersion}`
+          : '';
+        const resourceType =
+          resource.resourceType === 'ATTRIBUTE' ? 'attribute' : 'class';
+        const uri = `/model/${modelId}/${resourceType}/${resource.identifier}${versionPart}`;
+
         return {
           type: resource.resourceType,
           label:
@@ -189,7 +198,7 @@ export default function FrontPage() {
             resource.highlights['label.fi']?.[0] ||
             label,
           id: resource.id,
-          uri: resource.uri,
+          uri: uri,
         };
       });
       if (resources.length > 0) {

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -188,7 +188,12 @@ export default function FrontPage() {
           ? `?ver=${resource.fromVersion}`
           : '';
         const resourceType =
-          resource.resourceType === 'ATTRIBUTE' ? 'attribute' : 'class';
+          resource.resourceType == 'ATTRIBUTE'
+            ? 'attribute'
+            : resource.resourceType == 'ASSOCIATION'
+            ? 'association'
+            : 'class';
+
         const uri = `/model/${modelId}/${resourceType}/${resource.identifier}${versionPart}`;
 
         return {


### PR DESCRIPTION
Changed how the links are generated for resource matches in the search results.

Instead of: `https://iri.suomi.fi/model/foo/bar`

generate an internal url like: `/model/foo/attribute/bar?ver=1.2.3`


![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/b07f68dc-aa88-4ea2-bd1d-085b95042613)



