### PR TITLE
YTI-3812 UI fixes found in migration

### DIFF
--- a/datamodel-ui/src/common/utils/get-language-version.ts
+++ b/datamodel-ui/src/common/utils/get-language-version.ts
@@ -19,6 +19,8 @@ export function getLanguageVersion({
 
   if (data.fi) {
     return appendLocale ? `${data.fi} (fi)` : data.fi;
+  } else if (data.en) {
+    return appendLocale ? `${data.en} (en)` : data.en;
   }
 
   if (Object.keys(data).length > 0) {

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -31,6 +31,8 @@ import { useUpdateClassResrictionTargetMutation } from '@app/common/components/c
 import getApiError from '@app/common/utils/get-api-errors';
 import { useEffect, useState } from 'react';
 import ResourceError from '@app/common/components/resource-error';
+import { useRouter } from 'next/router';
+import { getSlugAsString } from '@app/common/utils/parse-slug';
 
 interface ResourceInfoProps {
   data: SimpleResource;
@@ -60,6 +62,7 @@ export default function ResourceInfo({
   const { t, i18n } = useTranslation('common');
   const [open, setOpen] = useState(false);
   const dispatch = useStoreDispatch();
+  const router = useRouter();
 
   const {
     data: resourceData,
@@ -87,7 +90,7 @@ export default function ResourceInfo({
 
   const handleChangeTarget = (newTarget?: InternalClassInfo) => {
     updateTarget({
-      prefix: data.modelId,
+      prefix: getSlugAsString(router.query.slug) ?? data.modelId,
       identifier: classId,
       uri: data.uri,
       currentTarget: targetInClassRestriction?.uri,

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -29,6 +29,8 @@ import ClassModal from '../class-modal';
 import { InternalClassInfo } from '@app/common/interfaces/internal-class.interface';
 import { default as NextLink } from 'next/link';
 import { UriData } from '@app/common/interfaces/uri.interface';
+import { getSlugAsString } from '@app/common/utils/parse-slug';
+import { useRouter } from 'next/router';
 
 export default function CommonViewContent({
   modelId,
@@ -63,6 +65,7 @@ export default function CommonViewContent({
         !applicationProfile || !data.codeLists || data.codeLists.length === 0,
     }
   );
+  const router = useRouter();
 
   function getCodeListLabel(uri: string) {
     if (!codesResult) {
@@ -545,7 +548,7 @@ export default function CommonViewContent({
                     })}
                     mode="select"
                     handleFollowUp={handleChangeTarget}
-                    modelId={modelId}
+                    modelId={getSlugAsString(router.query.slug) ?? modelId}
                     applicationProfile={applicationProfile}
                   />
                 </div>

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -277,9 +277,9 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
 
             return false;
           })
-          .map((r) => (
+          .map((r, idx) => (
             <Resource
-              key={`${id}-child-${r.identifier}`}
+              key={`${id}-child-${r.identifier}-${idx}`}
               className="node-resource"
               onClick={() => handleResourceClick(r.identifier, r.type, r.uri)}
               $highlight={getResourceHighlighted(r.identifier, r.type)}


### PR DESCRIPTION
- fix duplicate ids when listing resources in class node
- use model id from router, because actions with external references refers to the wrong model id
- prefer english language when display localized content