### PR TITLE
YTI-3694 don't show empty multilingual blocks

### DIFF
--- a/terminology-ui/src/common/components/block/multilingual-block.tsx
+++ b/terminology-ui/src/common/components/block/multilingual-block.tsx
@@ -21,7 +21,11 @@ export default function MultilingualBlock<T>({
   extra,
   id,
 }: MultilingualBlockProps<T>) {
-  if (!data) {
+  if (
+    !data ||
+    (typeof data === 'string' && data === '') ||
+    (Array.isArray(data) && data.length === 0)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
If the data provided to `MultilingualBlock` is empty, don't render anything.

This check was already there, but didn't take into account that the data might be an array.

Example in the concept page:

Before:
![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/ebb5e69e-6d39-468d-bb97-507946669f62)

After:

![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/9cc44517-578d-4fb9-bc6a-e5ab16354fa0)
