### PR TITLE
add CODEOWNERS with default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @urhot @kkyttala


### PR DESCRIPTION
Added `CODEOWNERS` with default reviewers.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners