### PR TITLE
YTI-2718 filter child organizations from the public view

### DIFF
--- a/terminology-ui/src/common/components/info-dropdown/info-expander.test.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.test.tsx
@@ -13,10 +13,17 @@ import { adminControlsSlice } from '../admin-controls/admin-controls.slice';
 import { vocabularyApi } from '../vocabulary/vocabulary.slice';
 import { subscriptionApi } from '../subscription/subscription.slice';
 import { screen, waitFor } from '@testing-library/react';
+import { terminologySearchApi } from '../terminology-search/terminology-search.slice';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
-const reducers = [adminControlsSlice, vocabularyApi, loginApi, subscriptionApi];
+const reducers = [
+  adminControlsSlice,
+  vocabularyApi,
+  loginApi,
+  subscriptionApi,
+  terminologySearchApi,
+];
 
 describe('infoExpander', () => {
   it('should render export button', async () => {

--- a/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
@@ -52,9 +52,13 @@ const CopyTerminologyModal = dynamic(() => import('../copy-terminology-modal'));
 
 interface InfoExpanderProps {
   data?: VocabularyInfoDTO;
+  childOrganizations?: string[];
 }
 
-export default function InfoExpander({ data }: InfoExpanderProps) {
+export default function InfoExpander({
+  data,
+  childOrganizations,
+}: InfoExpanderProps) {
   const { t, i18n } = useTranslation('common');
   const { urlState } = useUrlState();
   const router = useRouter();
@@ -66,6 +70,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
     urlState,
     language: i18n.language,
   });
+
   const dispatch = useStoreDispatch();
 
   if (!data) {
@@ -323,7 +328,12 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         <BasicBlock title={t('vocabulary-info-organization')} id="organization">
           <PropertyList>
             {data.references.contributor
-              ?.filter((c) => c && c.properties.prefLabel)
+              ?.filter(
+                (c) =>
+                  c &&
+                  c.properties.prefLabel &&
+                  !childOrganizations?.includes(c.id)
+              )
               .map((contributor) => (
                 <li key={contributor.id}>
                   <PropertyValue property={contributor?.properties.prefLabel} />

--- a/terminology-ui/src/common/components/terminology-components/organization-selector.tsx
+++ b/terminology-ui/src/common/components/terminology-components/organization-selector.tsx
@@ -33,7 +33,10 @@ export default function OrganizationSelector({
     data: organizations,
     isLoading,
     isError,
-  } = useGetOrganizationsQuery(i18n.language);
+  } = useGetOrganizationsQuery({
+    language: i18n.language,
+    showChildOrganizations: true,
+  });
   const [selectedOrganizations, setSelectedOrganizations] = useState<
     MultiSelectData[]
   >(

--- a/terminology-ui/src/common/components/terminology-search/terminology-search.slice.tsx
+++ b/terminology-ui/src/common/components/terminology-search/terminology-search.slice.tsx
@@ -50,9 +50,14 @@ export const terminologySearchApi = createApi({
         method: 'GET',
       }),
     }),
-    getOrganizations: builder.query<OrganizationSearchResult[], string>({
+    getOrganizations: builder.query<
+      OrganizationSearchResult[],
+      { language: string; showChildOrganizations?: boolean }
+    >({
       query: (value) => ({
-        url: `/v2/organizations?language=${value}`,
+        url: `/v2/organizations?language=${
+          value.language
+        }&showChildOrganizations=${value.showChildOrganizations ?? false}`,
         method: 'GET',
       }),
     }),

--- a/terminology-ui/src/common/interfaces/terminology.interface.ts
+++ b/terminology-ui/src/common/interfaces/terminology.interface.ts
@@ -58,6 +58,9 @@ export interface OrganizationSearchResult {
   properties: {
     prefLabel: Property;
   };
+  references: {
+    parent: OrganizationSearchResult;
+  };
   type: {
     graph: {
       id: string;

--- a/terminology-ui/src/modules/own-information/index.tsx
+++ b/terminology-ui/src/modules/own-information/index.tsx
@@ -29,7 +29,10 @@ export default function OwnInformation() {
   const user = useSelector(selectLogin());
   const { breakpoint } = useBreakpoints();
   const { t, i18n } = useTranslation('own-information');
-  const { data: organizations } = useGetOrganizationsQuery(i18n.language);
+  const { data: organizations } = useGetOrganizationsQuery({
+    language: i18n.language,
+    showChildOrganizations: true,
+  });
   const { data: subscriptions, refetch: refetchSubscriptions } =
     useGetSubscriptionsQuery();
   const { data: requests } = useGetRequestsQuery();

--- a/terminology-ui/src/modules/terminology-search/index.tsx
+++ b/terminology-ui/src/modules/terminology-search/index.tsx
@@ -55,7 +55,10 @@ export default function TerminologySearch() {
     i18n.language
   );
   const { data: orgsData, error: organizationsError } =
-    useGetOrganizationsQuery(i18n.language);
+    useGetOrganizationsQuery({
+      language: i18n.language,
+      showChildOrganizations: false,
+    });
   const { data: counts, error: countsError } = useGetCountsQuery(null);
   const dispatch = useStoreDispatch();
   const [showModal, setShowModal] = useState(false);

--- a/terminology-ui/src/modules/vocabulary/index.tsx
+++ b/terminology-ui/src/modules/vocabulary/index.tsx
@@ -51,6 +51,7 @@ import InfoExpander from '@app/common/components/info-dropdown/info-expander';
 import { useStoreDispatch } from '@app/store';
 import { setTitle } from '@app/common/components/title/title.slice';
 import { StatusChip } from 'yti-common-ui/status-chip';
+import { useGetOrganizationsQuery } from '@app/common/components/terminology-search/terminology-search.slice';
 
 const NewConceptModal = dynamic(
   () => import('@app/common/components/new-concept-modal')
@@ -87,6 +88,14 @@ export default function Vocabulary({ id }: VocabularyProps) {
     id,
   });
   const { data: counts } = useGetVocabularyCountQuery(id);
+  const {
+    data: organizationsData,
+    isLoading: isOrganizationsLoading,
+    isError: organizationsError,
+  } = useGetOrganizationsQuery({
+    language: i18n.language,
+    showChildOrganizations: true,
+  });
   const [showModal, setShowModal] = useState(false);
   const [showLoadingConcepts, setShowLoadingConcepts] = useState(false);
   const [showLoadingCollections, setShowLoadingCollections] = useState(true);
@@ -132,6 +141,15 @@ export default function Vocabulary({ id }: VocabularyProps) {
       type: t('vocabulary-info-collection'),
     }));
   }, [collectionsData, t, id, urlState.lang, i18n.language]);
+
+  const childOrganizations = useMemo(() => {
+    if (isOrganizationsLoading || organizationsError) {
+      return [];
+    }
+    return organizationsData
+      ?.filter((org) => org.references.parent)
+      .map((org) => org.id);
+  }, [organizationsData, isOrganizationsLoading, organizationsError]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -222,7 +240,10 @@ export default function Vocabulary({ id }: VocabularyProps) {
                   )}
                 </StatusChip>
               </TitleTypeAndStatusWrapper>
-              <InfoExpander data={info} />
+              <InfoExpander
+                data={info}
+                childOrganizations={childOrganizations}
+              />
             </>
           }
         />

--- a/terminology-ui/src/pages/index.tsx
+++ b/terminology-ui/src/pages/index.tsx
@@ -120,7 +120,12 @@ export const getServerSideProps = createCommonGetServerSideProps(
       getSearchResult.initiate({ urlState: urlState, language: locale ?? 'fi' })
     );
     store.dispatch(getGroups.initiate(locale ?? 'fi'));
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(
+      getOrganizations.initiate({
+        language: locale ?? 'fi',
+        showChildOrganizations: false,
+      })
+    );
     store.dispatch(getCounts.initiate(null));
 
     await Promise.all(store.dispatch(terminologyGetRunningQueriesThunk()));

--- a/terminology-ui/src/pages/own-information.tsx
+++ b/terminology-ui/src/pages/own-information.tsx
@@ -46,7 +46,12 @@ export default function OwnInformationPage(props: OwnInformationPageProps) {
 
 export const getServerSideProps = createCommonGetServerSideProps(
   async ({ store, locale }) => {
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(
+      getOrganizations.initiate({
+        language: locale ?? 'fi',
+        showChildOrganizations: true,
+      })
+    );
     store.dispatch(getSubscriptions.initiate());
     store.dispatch(getRequests.initiate());
 

--- a/terminology-ui/src/pages/terminology/[terminologyId]/edit.tsx
+++ b/terminology-ui/src/pages/terminology/[terminologyId]/edit.tsx
@@ -62,7 +62,12 @@ export const getServerSideProps = createCommonGetServerSideProps(
     }
 
     store.dispatch(getVocabulary.initiate({ id: terminologyId }));
-    store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
+    store.dispatch(
+      getOrganizations.initiate({
+        language: locale ?? 'fi',
+        showChildOrganizations: true,
+      })
+    );
     store.dispatch(getGroups.initiate(locale ?? 'fi'));
 
     await Promise.all(store.dispatch(getRunningQueriesThunk()));


### PR DESCRIPTION
- Show only parent organizations in terminology, concept and collection pages
- Modify getOrganizations query by adding `showChildOrganizations` parameter

Backend changes: https://github.com/VRK-YTI/yti-terminology-api/pull/129