### PR TITLE
change graph settings modal position

### DIFF
--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -106,104 +106,106 @@ export default function ModelTools({
   }
 
   return (
-    <ToolsPanel position="top-right">
-      <div
-        style={{
-          marginRight: '10px',
-        }}
-      >
-        <ToolsButtonGroup $isSmall={isSmall}>
-          <Button
-            id="graph-tools_zoom-in"
-            icon={<IconPlus />}
-            onClick={() =>
-              setViewport({
-                x: transform[0],
-                y: transform[1],
-                zoom: transform[2] + 0.25,
-              })
-            }
-            onMouseEnter={(ref) => setRef(ref.currentTarget)}
-            onMouseLeave={() => setRef(null)}
-          />
-          <Button
-            id="graph-tools_zoom-out"
-            icon={<IconMinus />}
-            onClick={() =>
-              setViewport({
-                x: transform[0],
-                y: transform[1],
-                zoom: transform[2] - 0.25,
-              })
-            }
-            onMouseEnter={(ref) => setRef(ref.currentTarget)}
-            onMouseLeave={() => setRef(null)}
-          />
-          <Button
-            id="graph-tools_fullscreen"
-            icon={<IconFullscreen />}
-            onClick={() => {
-              dispatch(setModelTools('fullScreen', !tools.fullScreen));
-            }}
-            onMouseEnter={(ref) => setRef(ref.currentTarget)}
-            onMouseLeave={() => setRef(null)}
-          />
-          <Button
-            id="graph-tools_reset-positions"
-            icon={<IconSwapRounded />}
-            onClick={() => handleResetPosition()}
-            onMouseEnter={(ref) => setRef(ref.currentTarget)}
-            onMouseLeave={() => setRef(null)}
-          />
-          <Button
-            id="graph-tools_zoom-to"
-            icon={<IconMapMyLocation />}
-            onClick={() => handleCenterNode()}
-            onMouseEnter={(ref) => setRef(ref.currentTarget)}
-            onMouseLeave={() => setRef(null)}
-          />
-
-          <DownloadPicture modelId={modelId} setRef={setRef} />
-
-          {hasPermission && (
+    <>
+      {tooltipOpen && (
+        <>
+          {renderLibraryVersion()}
+          {renderAppProfileVersion()}
+        </>
+      )}
+      <ToolsPanel position="top-right">
+        <div
+          style={{
+            marginRight: '10px',
+          }}
+        >
+          <ToolsButtonGroup $isSmall={isSmall}>
             <Button
-              id="graph-tools_save-positions"
-              icon={<IconSave />}
-              onClick={() => dispatch(setSavePosition(true))}
+              id="graph-tools_zoom-in"
+              icon={<IconPlus />}
+              onClick={() =>
+                setViewport({
+                  x: transform[0],
+                  y: transform[1],
+                  zoom: transform[2] + 0.25,
+                })
+              }
               onMouseEnter={(ref) => setRef(ref.currentTarget)}
               onMouseLeave={() => setRef(null)}
             />
-          )}
+            <Button
+              id="graph-tools_zoom-out"
+              icon={<IconMinus />}
+              onClick={() =>
+                setViewport({
+                  x: transform[0],
+                  y: transform[1],
+                  zoom: transform[2] - 0.25,
+                })
+              }
+              onMouseEnter={(ref) => setRef(ref.currentTarget)}
+              onMouseLeave={() => setRef(null)}
+            />
+            <Button
+              id="graph-tools_fullscreen"
+              icon={<IconFullscreen />}
+              onClick={() => {
+                dispatch(setModelTools('fullScreen', !tools.fullScreen));
+              }}
+              onMouseEnter={(ref) => setRef(ref.currentTarget)}
+              onMouseLeave={() => setRef(null)}
+            />
+            <Button
+              id="graph-tools_reset-positions"
+              icon={<IconSwapRounded />}
+              onClick={() => handleResetPosition()}
+              onMouseEnter={(ref) => setRef(ref.currentTarget)}
+              onMouseLeave={() => setRef(null)}
+            />
+            <Button
+              id="graph-tools_zoom-to"
+              icon={<IconMapMyLocation />}
+              onClick={() => handleCenterNode()}
+              onMouseEnter={(ref) => setRef(ref.currentTarget)}
+              onMouseLeave={() => setRef(null)}
+            />
 
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'row-reverse',
-              gap: '5px',
-            }}
-          >
-            {renderLibraryVersion()}
-            {renderAppProfileVersion()}
-          </div>
-        </ToolsButtonGroup>
-      </div>
+            <DownloadPicture modelId={modelId} setRef={setRef} />
 
-      {ref && (
-        <TipTooltipWrapper
-          $x={ref && ref.getBoundingClientRect().x}
-          $y={ref && ref.getBoundingClientRect().y}
-        >
-          <Tooltip
-            ariaCloseButtonLabelText=""
-            ariaToggleButtonLabelText=""
-            anchorElement={ref}
-            open={showHover}
+            {hasPermission && (
+              <Button
+                id="graph-tools_save-positions"
+                icon={<IconSave />}
+                onClick={() => dispatch(setSavePosition(true))}
+                onMouseEnter={(ref) => setRef(ref.currentTarget)}
+                onMouseLeave={() => setRef(null)}
+              />
+            )}
+            <Button
+              icon={tooltipOpen ? <IconChevronRight /> : <IconChevronLeft />}
+              variant="secondary"
+              onClick={() => setTooltipOpen(!tooltipOpen)}
+            />
+          </ToolsButtonGroup>
+        </div>
+
+        {ref && (
+          <TipTooltipWrapper
+            $x={ref && ref.getBoundingClientRect().x}
+            $y={ref && ref.getBoundingClientRect().y}
           >
-            {translateTooltip(ref.id, t)}
-          </Tooltip>
-        </TipTooltipWrapper>
-      )}
-    </ToolsPanel>
+            <Tooltip
+              ariaCloseButtonLabelText=""
+              ariaToggleButtonLabelText=""
+              anchorElement={ref}
+              open={showHover}
+            >
+              {translateTooltip(ref.id, t)}
+            </Tooltip>
+          </TipTooltipWrapper>
+        )}
+      </ToolsPanel>
+    </>
   );
 
   function renderLibraryVersion() {
@@ -211,75 +213,65 @@ export default function ModelTools({
       return <></>;
     }
 
+    if (!tooltipOpen) {
+      return <></>;
+    }
+
     return (
-      <>
-        <Button
-          icon={tooltipOpen ? <IconChevronRight /> : <IconChevronLeft />}
-          variant="secondary"
-          onClick={() => setTooltipOpen(!tooltipOpen)}
-        />
-        {tooltipOpen && (
-          <ToolsTooltip>
-            <div>
-              <Text variant="bold">{t('graph-settings')}</Text>
-            </div>
+      <ToolsTooltip>
+        <div>
+          <Text variant="bold">{t('graph-settings')}</Text>
+        </div>
 
-            <ToggleButtonGroup>
-              <ToggleButton
-                checked={tools.showAttributes}
-                onClick={() =>
-                  dispatch(
-                    setModelTools('showAttributes', !tools.showAttributes)
-                  )
-                }
-              >
-                {t('show-attributes')}
-              </ToggleButton>
-              <ToggleButton
-                checked={tools.showAssociations}
-                onClick={() =>
-                  dispatch(
-                    setModelTools('showAssociations', !tools.showAssociations)
-                  )
-                }
-              >
-                {t('show-associations')}
-              </ToggleButton>
-              <ToggleButton
-                checked={tools.showClassHighlights}
-                onClick={() =>
-                  dispatch(
-                    setModelTools(
-                      'showClassHighlights',
-                      !tools.showClassHighlights
-                    )
-                  )
-                }
-              >
-                {t('highlight-class-associations')}
-              </ToggleButton>
-            </ToggleButtonGroup>
+        <ToggleButtonGroup>
+          <ToggleButton
+            checked={tools.showAttributes}
+            onClick={() =>
+              dispatch(setModelTools('showAttributes', !tools.showAttributes))
+            }
+          >
+            {t('show-attributes')}
+          </ToggleButton>
+          <ToggleButton
+            checked={tools.showAssociations}
+            onClick={() =>
+              dispatch(
+                setModelTools('showAssociations', !tools.showAssociations)
+              )
+            }
+          >
+            {t('show-associations')}
+          </ToggleButton>
+          <ToggleButton
+            checked={tools.showClassHighlights}
+            onClick={() =>
+              dispatch(
+                setModelTools('showClassHighlights', !tools.showClassHighlights)
+              )
+            }
+          >
+            {t('highlight-class-associations')}
+          </ToggleButton>
+        </ToggleButtonGroup>
 
-            <div>
-              <RadioButtonGroup
-                labelText={t('show-from-resource')}
-                name="resource"
-                value={tools.showByName ? 'name' : 'id'}
-                onChange={(e) =>
-                  e === 'name'
-                    ? dispatch(setModelTools('showByName', true))
-                    : dispatch(setModelTools('showById', false))
-                }
-              >
-                <RadioButton value="name">{t('name')}</RadioButton>
-                <RadioButton value="id">
-                  {t('prefix')} / {t('technical-name')}
-                </RadioButton>
-              </RadioButtonGroup>
-            </div>
-          </ToolsTooltip>
-        )}
-      </>
+        <div>
+          <RadioButtonGroup
+            labelText={t('show-from-resource')}
+            name="resource"
+            value={tools.showByName ? 'name' : 'id'}
+            onChange={(e) =>
+              e === 'name'
+                ? dispatch(setModelTools('showByName', true))
+                : dispatch(setModelTools('showById', false))
+            }
+          >
+            <RadioButton value="name">{t('name')}</RadioButton>
+            <RadioButton value="id">
+              {t('prefix')} / {t('technical-name')}
+            </RadioButton>
+          </RadioButtonGroup>
+        </div>
+      </ToolsTooltip>
     );
   }
 
@@ -288,82 +280,74 @@ export default function ModelTools({
       return <></>;
     }
 
+    if (!tooltipOpen) {
+      return <></>;
+    }
+
     return (
-      <>
-        <Button
-          icon={tooltipOpen ? <IconChevronRight /> : <IconChevronLeft />}
-          variant="secondary"
-          onClick={() => setTooltipOpen(!tooltipOpen)}
-        />
-        {tooltipOpen && (
-          <ToolsTooltip>
-            <div>
-              <Text variant="bold">{t('graph-settings')}</Text>
-            </div>
+      <ToolsTooltip>
+        <div>
+          <Text variant="bold">{t('graph-settings')}</Text>
+        </div>
 
-            <ToggleButtonGroup>
-              <HintText>{t('show')}</HintText>
-              <ToggleButton
-                checked={tools.showAssociationRestrictions}
-                onClick={() =>
-                  dispatch(
-                    setModelTools(
-                      'showAssociationRestrictions',
-                      !tools.showAssociationRestrictions
-                    )
-                  )
-                }
-              >
-                {t('association-restr')}
-              </ToggleButton>
-              <ToggleButton
-                checked={tools.showAttributeRestrictions}
-                onClick={() =>
-                  dispatch(
-                    setModelTools(
-                      'showAttributeRestrictions',
-                      !tools.showAttributeRestrictions
-                    )
-                  )
-                }
-              >
-                {t('attribute-restr')}
-              </ToggleButton>
-              <ToggleButton
-                checked={tools.showClassHighlights}
-                onClick={() =>
-                  dispatch(
-                    setModelTools(
-                      'showClassHighlights',
-                      !tools.showClassHighlights
-                    )
-                  )
-                }
-              >
-                {t('highlight-class-association-restrictions')}
-              </ToggleButton>
-            </ToggleButtonGroup>
+        <ToggleButtonGroup>
+          <HintText>{t('show')}</HintText>
+          <ToggleButton
+            checked={tools.showAssociationRestrictions}
+            onClick={() =>
+              dispatch(
+                setModelTools(
+                  'showAssociationRestrictions',
+                  !tools.showAssociationRestrictions
+                )
+              )
+            }
+          >
+            {t('association-restr')}
+          </ToggleButton>
+          <ToggleButton
+            checked={tools.showAttributeRestrictions}
+            onClick={() =>
+              dispatch(
+                setModelTools(
+                  'showAttributeRestrictions',
+                  !tools.showAttributeRestrictions
+                )
+              )
+            }
+          >
+            {t('attribute-restr')}
+          </ToggleButton>
+          <ToggleButton
+            checked={tools.showClassHighlights}
+            onClick={() =>
+              dispatch(
+                setModelTools('showClassHighlights', !tools.showClassHighlights)
+              )
+            }
+          >
+            {t('highlight-class-association-restrictions')}
+          </ToggleButton>
+        </ToggleButtonGroup>
 
-            <div>
-              <RadioButtonGroup
-                labelText={t('show-from-resource')}
-                name="resource"
-                value={tools.showByName ? 'name' : 'id'}
-                onChange={(e) =>
-                  e === 'name'
-                    ? dispatch(setModelTools('showByName', true))
-                    : dispatch(setModelTools('showById', false))
-                }
-              >
-                <RadioButton value="name">{t('name')}</RadioButton>
-                <RadioButton value="id">
-                  {t('prefix')} / {t('technical-name')}
-                </RadioButton>
-              </RadioButtonGroup>
-            </div>
-          </ToolsTooltip>
-        )}
-      </>
+        <div>
+          <RadioButtonGroup
+            labelText={t('show-from-resource')}
+            name="resource"
+            value={tools.showByName ? 'name' : 'id'}
+            onChange={(e) =>
+              e === 'name'
+                ? dispatch(setModelTools('showByName', true))
+                : dispatch(setModelTools('showById', false))
+            }
+          >
+            <RadioButton value="name">{t('name')}</RadioButton>
+            <RadioButton value="id">
+              {t('prefix')} / {t('technical-name')}
+            </RadioButton>
+          </RadioButtonGroup>
+        </div>
+      </ToolsTooltip>
     );
   }
 }

--- a/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
+++ b/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
@@ -15,6 +15,10 @@ export const ToolsTooltip = styled.div`
   gap: ${(props) => props.theme.suomifi.spacing.s};
   padding: ${(props) => props.theme.suomifi.spacing.s};
 
+  position: absolute;
+  right: 60px;
+  top: 20px;
+
   * > {
     min-width: 100%;
   }


### PR DESCRIPTION
The settings modal was previously anchored to the button that opens it, positioning it so that it sometimes goes off-screen on smaller displays.

The modal is now changed to have absolute positioning relative to the toolbar, effectively anchoring it at top right of the screen.

**Before:**

![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/f68a7944-6519-47c1-88db-86a29b653c1f)

**After:**

![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/a94d306c-20de-42ab-8f92-232e521290d0)
