### PR TITLE
YTI-3824 fix localized data order

### DIFF
--- a/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
@@ -44,6 +44,7 @@ import UpdateWithFileModal from '../update-with-file-modal';
 import StatusMassEdit from '../status-mass-edit';
 import isEmail from 'validator/lib/isEmail';
 import { useRouter } from 'next/router';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 const Subscription = dynamic(
   () => import('@app/common/components/subscription/subscription')
@@ -155,7 +156,9 @@ export default function InfoExpander({
 
         <PropertyBlock
           title={t('vocabulary-info-languages')}
-          property={data.properties.language}
+          property={data.properties.language
+            ?.slice()
+            .sort((a, b) => compareLocales(a.value, b.value))}
           delimiter=", "
           valueAccessor={({ value }) => {
             // if no translation found for language, return only language code

--- a/terminology-ui/src/common/components/new-concept-modal/index.tsx
+++ b/terminology-ui/src/common/components/new-concept-modal/index.tsx
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import { Button, IconPlus } from 'suomifi-ui-components';
 import { useGetAuthenticatedUserMutMutation } from '../login/login.slice';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 const NewConceptModalDynamic = dynamic(() => import('./new-concept-modal'));
 
@@ -40,7 +41,7 @@ export default function NewConceptModal({
       {visible && (
         <NewConceptModalDynamic
           terminologyId={terminologyId}
-          languages={languages}
+          languages={languages.slice().sort(compareLocales)}
           visible={visible}
           setVisible={setVisible}
           unauthenticatedUser={authenticatedUser.data?.anonymous}

--- a/terminology-ui/src/common/utils/compare-locals.ts
+++ b/terminology-ui/src/common/utils/compare-locals.ts
@@ -22,6 +22,10 @@ export function compareLocales(
     return t1Lang === 'sv' ? -1 : 1;
   }
 
+  if (t1Lang === 'en' || t2Lang === 'en') {
+    return t1Lang === 'en' ? -1 : 1;
+  }
+
   if (t1Lang !== t2Lang) {
     return t1Lang > t2Lang ? 1 : -1;
   }

--- a/terminology-ui/src/modules/concept/utils.tsx
+++ b/terminology-ui/src/modules/concept/utils.tsx
@@ -30,12 +30,12 @@ const termTypeOrder: { [key: string]: string } = {
  * @param type term's type
  * @returns
  */
-function getCompareKey(term: Term, type: string) {
+function getCompareKey(term: Term, type: string, index: number) {
   const prefLabel = term.properties.prefLabel?.[0];
   const langKey = `${
     langOrder[prefLabel?.lang ?? ''] ?? `x_${prefLabel?.lang}`
   }`;
-  return `${langKey}_${termTypeOrder[type] ?? 'x'}`;
+  return `${langKey}_${termTypeOrder[type] ?? 'x'}_${index}`;
 }
 
 export function getBlockData(t: TFunction, concept?: Concept) {
@@ -44,25 +44,25 @@ export function getBlockData(t: TFunction, concept?: Concept) {
   }
 
   const terms = [
-    ...(concept.references.prefLabelXl ?? []).map((term) => ({
+    ...(concept.references.prefLabelXl ?? []).map((term, idx) => ({
       term,
       type: t('field-terms-preferred', { ns: 'concept' }),
-      compareKey: getCompareKey(term, 'prefLabelXl'),
+      compareKey: getCompareKey(term, 'prefLabelXl', idx),
     })),
-    ...(concept.references.altLabelXl ?? []).map((term) => ({
+    ...(concept.references.altLabelXl ?? []).map((term, idx) => ({
       term,
       type: t('field-terms-alternative', { ns: 'concept' }),
-      compareKey: getCompareKey(term, 'altLabelXl'),
+      compareKey: getCompareKey(term, 'altLabelXl', idx),
     })),
-    ...(concept.references.notRecommendedSynonym ?? []).map((term) => ({
+    ...(concept.references.notRecommendedSynonym ?? []).map((term, idx) => ({
       term,
       type: t('field-terms-non-recommended', { ns: 'concept' }),
-      compareKey: getCompareKey(term, 'notRecommendedSynonym'),
+      compareKey: getCompareKey(term, 'notRecommendedSynonym', idx),
     })),
     ...(concept.references.hiddenTerm ?? []).map((term) => ({
       term,
       type: t('field-terms-hidden', { ns: 'concept' }),
-      compareKey: getCompareKey(term, 'hiddenTerm'),
+      compareKey: getCompareKey(term, 'hiddenTerm', 0),
     })),
   ].sort((t1, t2) => t1.compareKey.localeCompare(t2.compareKey));
 

--- a/terminology-ui/src/modules/edit-collection/concept-picker/expander-concept-content.tsx
+++ b/terminology-ui/src/modules/edit-collection/concept-picker/expander-concept-content.tsx
@@ -8,6 +8,7 @@ import { useGetVocabularyQuery } from '@app/common/components/vocabulary/vocabul
 import { useTranslation } from 'next-i18next';
 import { ExpanderContent } from 'suomifi-ui-components';
 import { ExpanderConceptContent as ExpanderConceptContentType } from './concept-picker.types';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 export function ExpanderConceptContent({
   concept,
@@ -26,21 +27,25 @@ export function ExpanderConceptContent({
     <ExpanderContent>
       <MultilingualPropertyBlock
         title={t('recommended-terms')}
-        data={Object.keys(concept.label).map((key) => ({
-          lang: key,
-          regex: '(?s)^.*$',
-          value: concept.label[key],
-        }))}
+        data={Object.keys(concept.label)
+          .map((key) => ({
+            lang: key,
+            regex: '(?s)^.*$',
+            value: concept.label[key],
+          }))
+          .sort(compareLocales)}
       />
 
       {concept.definition && (
         <MultilingualPropertyBlock
           title={t('definition')}
-          data={Object.keys(concept.definition).map((key) => ({
-            lang: key,
-            regex: '(?s)^.*$',
-            value: concept.definition[key],
-          }))}
+          data={Object.keys(concept.definition)
+            .map((key) => ({
+              lang: key,
+              regex: '(?s)^.*$',
+              value: concept.definition[key],
+            }))
+            .sort(compareLocales)}
         />
       )}
 

--- a/terminology-ui/src/modules/edit-collection/index.tsx
+++ b/terminology-ui/src/modules/edit-collection/index.tsx
@@ -36,6 +36,7 @@ import {
   useGetAuthenticatedUserMutMutation,
   useGetAuthenticatedUserQuery,
 } from '@app/common/components/login/login.slice';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 export default function EditCollection({
   terminologyId,
@@ -73,7 +74,10 @@ export default function EditCollection({
   const [isCreating, setIsCreating] = useState(false);
 
   const languages =
-    terminology?.properties.language?.map(({ value }) => value) ?? [];
+    terminology?.properties.language
+      ?.slice()
+      .sort((a, b) => compareLocales(a.value, b.value))
+      .map(({ value }) => value) ?? [];
 
   const [formData, setFormData] = useState<EditCollectionFormDataType>(
     setInitialData(collection)

--- a/terminology-ui/src/modules/edit-concept/index.tsx
+++ b/terminology-ui/src/modules/edit-concept/index.tsx
@@ -33,6 +33,7 @@ import { useBreakpoints } from 'yti-common-ui/media-query';
 import { translateStatus } from '@app/common/utils/translation-helpers';
 import { v4 } from 'uuid';
 import { StatusChip } from 'yti-common-ui/status-chip';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 interface EditConceptProps {
   terminologyId: string;
@@ -57,7 +58,10 @@ export default function EditConcept({
     useGetAuthenticatedUserMutMutation();
 
   const [languages] = useState(
-    terminology?.properties.language?.map(({ value }) => value) ?? []
+    terminology?.properties.language
+      ?.slice()
+      .sort((a, b) => compareLocales(a.value, b.value))
+      .map(({ value }) => value) ?? []
   );
   const [preferredTerms] = useState<
     {

--- a/terminology-ui/src/modules/vocabulary/terminology-list-filter.tsx
+++ b/terminology-ui/src/modules/vocabulary/terminology-list-filter.tsx
@@ -10,6 +10,7 @@ import Filter, {
 import useUrlState from '@app/common/utils/hooks/use-url-state';
 import { FilterTopPartBlock } from './vocabulary.styles';
 import { Property } from '@app/common/interfaces/termed-data-types.interface';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 export interface TerminologyListFilterProps {
   isModal?: boolean;
@@ -44,10 +45,13 @@ export function TerminologyListFilter({
         <LanguageFilter
           labelText={t('display-by-language')}
           languages={
-            languages?.map((lang) => ({
-              labelText: lang.value,
-              uniqueItemId: lang.value,
-            })) ?? []
+            languages
+              ?.slice()
+              ?.sort((a, b) => compareLocales(a.value, b.value))
+              ?.map((lang) => ({
+                labelText: lang.value,
+                uniqueItemId: lang.value,
+              })) ?? []
           }
         />
       </FilterTopPartBlock>


### PR DESCRIPTION
- Add english to language comparison
- Fix localized data and language list order: fi, sv, en, other languages in alphabetical order
- Fix also terms' order (actually related to YTI-3936) by adding index to the compare key (modules/concept/utils.tsx)