### PR TITLE
don't pass groups to the counts endpoint

### DIFF
--- a/datamodel-ui/src/common/components/counts/counts.slice.tsx
+++ b/datamodel-ui/src/common/components/counts/counts.slice.tsx
@@ -46,7 +46,10 @@ export const countApi = createApi({
       UrlState
     >({
       query: (urlState) => ({
-        url: getUrl(urlState),
+        url: getUrl({
+          ...urlState,
+          domain: [], // don't pass groups to the count endpoint YTI-3701
+        }),
         method: 'GET',
       }),
     }),


### PR DESCRIPTION
Currently the front page filters are a bit confusing, when selecting groups will affect the counts of other groups.

As an attempt to make the filtering less confusing, groups are no longer taken into account when requesting counts from the backend.