### PR TITLE
YTI-3808 show external resource info in expander

### DIFF
--- a/datamodel-ui/src/modules/class-view/external-resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/external-resource-info.tsx
@@ -1,0 +1,45 @@
+import { selectDisplayLang } from '@app/common/components/model/model.slice';
+import { SimpleResource } from '@app/common/interfaces/simple-resource.interface';
+import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import { useTranslation } from 'next-i18next';
+import { useSelector } from 'react-redux';
+import { BasicBlock } from 'yti-common-ui/block';
+import Separator from 'yti-common-ui/separator';
+
+export default function ExternalResourceInfo({
+  resource,
+  renderActions,
+}: {
+  resource: SimpleResource;
+  renderActions: () => void;
+}) {
+  const { t, i18n } = useTranslation('common');
+  const displayLang = useSelector(selectDisplayLang());
+
+  return (
+    <>
+      {renderActions()}
+      <Separator />
+
+      <BasicBlock title={t('name')}>
+        {getLanguageVersion({
+          data: resource.label,
+          lang: displayLang ?? i18n.language,
+        })}
+      </BasicBlock>
+
+      <BasicBlock title={t('description')}>
+        {resource.note ? (
+          getLanguageVersion({
+            data: resource.note,
+            lang: displayLang ?? i18n.language,
+          })
+        ) : (
+          <>{t('not-defined')}</>
+        )}
+      </BasicBlock>
+
+      <BasicBlock title="URI">{resource.uri}</BasicBlock>
+    </>
+  );
+}

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -38,6 +38,7 @@ import ResourceError from '@app/common/components/resource-error';
 import { useRouter } from 'next/router';
 import { getSlugAsString } from '@app/common/utils/parse-slug';
 import { useSelector } from 'react-redux';
+import ExternalResourceInfo from './external-resource-info';
 
 interface ResourceInfoProps {
   data: SimpleResource;
@@ -81,7 +82,7 @@ export default function ResourceInfo({
       applicationProfile,
       version: data.version,
     },
-    { skip: !open }
+    { skip: !open || !data.modelId }
   );
 
   const [updateTarget, updateResult] = useUpdateClassResrictionTargetMutation();
@@ -125,7 +126,7 @@ export default function ResourceInfo({
               data: data.label,
               lang: displayLang ?? i18n.language,
               appendLocale: true,
-            })} (${data.modelId}:${data.identifier})`}
+            })} (${data.curie})`}
           </PrimaryTextWrapper>
           <SecondaryTextWrapper>
             {data.range && !attribute
@@ -210,6 +211,9 @@ export default function ResourceInfo({
             handleChangeTarget={handleChangeTarget}
             targetInClassRestriction={targetInClassRestriction}
           />
+        )}
+        {!data.modelId && (
+          <ExternalResourceInfo resource={data} renderActions={renderActions} />
         )}
       </ExpanderContent>
     </Expander>


### PR DESCRIPTION
Skip loading if external resource. Instead, view resource's name, description and URI which are already available in the data

<img width="386" alt="Screenshot 2024-02-16 at 10 21 21" src="https://github.com/VRK-YTI/yti-ui/assets/16885816/618e9768-4c39-4c22-9a89-ef916b91c7d2">
