### PR TITLE
fix next.js error related to SSR

### DIFF
--- a/common-ui/components/formatted-date/index.tsx
+++ b/common-ui/components/formatted-date/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'next-i18next';
 import { Locale } from '../locale-chooser/use-locales';
 import format from './format';
+import { useEffect, useState } from 'react';
 
 export interface FormattedDateProps {
   date?: string;
@@ -8,10 +9,20 @@ export interface FormattedDateProps {
 
 export default function FormattedDate({ date }: FormattedDateProps) {
   const { i18n } = useTranslation('common');
+  const [fdate, setFdate] = useState<string | undefined>(undefined);
+
+  // To avoid error "Text content does not match server-rendered HTML",
+  // render the formatted date only on client-side
+  // https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only
+  useEffect(() => {
+    if (date) {
+      setFdate(format(date, i18n.language as Locale));
+    }
+  }, [date, i18n.language]);
 
   if (!date) {
     return null;
   }
 
-  return <>{format(date, i18n.language as Locale)}</>;
+  return <>{fdate}</>;
 }


### PR DESCRIPTION
In production build, we would frequently get errors:

* Minified React error 425;
* Minified React error 418;
* Minified React error 423;

Which translate to:

* Text content does not match server-rendered HTML
* Hydration failed because the initial UI does not match what was rendered on the server.
* There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.

Some possible reasons for these errors are found in nextjs documentation:

https://nextjs.org/docs/messages/react-hydration-error

In this case, the culprit appears to be the FormattedDate component, which uses `dayjs` to for date formatting.

As a workaround, the formatting is now done only on client-side.