### PR TITLE
fix graph zooming using toolbar

### DIFF
--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -63,6 +63,22 @@ export default function ModelTools({
   const [ref, setRef] = useState<HTMLButtonElement | null>(null);
   const [showHover, setShowHover] = useState(false);
 
+  const zoomLevels = [
+    0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 3.5, 4, 5,
+  ];
+
+  const zoom = (currentZoom: number, direction: 'in' | 'out'): number => {
+    const closestZoom = zoomLevels.reduce((prev, curr) =>
+      Math.abs(curr - currentZoom) < Math.abs(prev - currentZoom) ? curr : prev
+    );
+
+    return (
+      zoomLevels[
+        zoomLevels.indexOf(closestZoom) + (direction == 'in' ? 1 : -1)
+      ] ?? closestZoom
+    );
+  };
+
   const handleResetPosition = () => {
     dispatch(setResetPosition(true));
   };
@@ -127,7 +143,7 @@ export default function ModelTools({
                 setViewport({
                   x: transform[0],
                   y: transform[1],
-                  zoom: transform[2] + 0.25,
+                  zoom: zoom(transform[2], 'in'),
                 })
               }
               onMouseEnter={(ref) => setRef(ref.currentTarget)}
@@ -140,7 +156,7 @@ export default function ModelTools({
                 setViewport({
                   x: transform[0],
                   y: transform[1],
-                  zoom: transform[2] - 0.25,
+                  zoom: zoom(transform[2], 'out'),
                 })
               }
               onMouseEnter={(ref) => setRef(ref.currentTarget)}

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -449,7 +449,7 @@ const GraphContent = ({
           minZoom: 1,
         }}
         maxZoom={5}
-        minZoom={0.2}
+        minZoom={0.25}
       >
         <GraphNotification hasChanges={graphHasChanges} />
         {children}


### PR DESCRIPTION
The zoom buttons in the graph toolbar would zoom out to a negative value, flipping the graph.

Zoom levels are now fixed values, ranging from 0.25 to 5.

Zooming with mouse wheel is not limited to these values, but are also capped at 0.25 and 5.

[Screencast from 2024-02-22 10-58-09.webm](https://github.com/VRK-YTI/yti-ui/assets/25614946/7c59f699-a6da-4094-8ac6-eff60ba0061c)
