### PR TITLE
fixes to paging with DetachedPagination

### DIFF
--- a/common-ui/components/pagination/index.tsx
+++ b/common-ui/components/pagination/index.tsx
@@ -17,6 +17,7 @@ export default function Pagination({ maxPages }: PaginationProps) {
     return null;
   }
 
+  // 50 is a hard coded value from front page. These are used for aria text.
   const firstShown = (urlState.page - 1) * 50 + 1;
   const lastShown = urlState.page * 50;
 

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -90,7 +90,7 @@ export default function ClassView({
     query: query ?? '',
     limitToDataModel: modelId,
     pageSize: 20,
-    pageFrom: (currentPage - 1) * 20,
+    pageFrom: currentPage - 1,
     resourceTypes: [ResourceType.CLASS],
     fromVersion: version,
   });

--- a/datamodel-ui/src/modules/model/search-view.tsx
+++ b/datamodel-ui/src/modules/model/search-view.tsx
@@ -49,7 +49,7 @@ export default function SearchView({
     query: query ?? '',
     limitToDataModel: modelId,
     pageSize: 20,
-    pageFrom: (currentPage - 1) * 20,
+    pageFrom: currentPage - 1,
     resourceTypes: [],
     fromVersion: version,
   });

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -90,7 +90,7 @@ export default function ResourceView({
     query: query ?? '',
     limitToDataModel: modelId,
     pageSize: 20,
-    pageFrom: (currentPage - 1) * 20,
+    pageFrom: currentPage - 1,
     resourceTypes: [type],
     fromVersion: version,
   });


### PR DESCRIPTION
"pageFrom" was still being set wrong, causing incorrectly paged API searches.

Every instance of `DetachedPagination` should now work properly:
* Switching pages works
* Last page is calculated correctly
* API calls don't have incorrectly multiplied `pageFrom` values