### PR TITLE
show search results with no search parameter

### DIFF
--- a/datamodel-ui/src/modules/linked-model/list-form.tsx
+++ b/datamodel-ui/src/modules/linked-model/list-form.tsx
@@ -54,25 +54,22 @@ export default function ListForm({
       status: ['SUGGESTED', 'VALID', 'DRAFT'],
     });
 
-  const { data: models } = useGetSearchModelsQuery(
-    {
-      lang: i18n.language,
-      urlState: {
-        domain: searchParams.groups ?? [],
-        lang: contentLanguage ?? i18n.language,
-        organization: '',
-        page: searchParams.pageFrom ?? 0,
-        q: searchParams.query,
-        status: searchParams.status ?? [],
-        type: '',
-        types:
-          applicationProfile && searchParams.limitToModelType
-            ? [searchParams.limitToModelType]
-            : ['LIBRARY'],
-      },
+  const { data: models } = useGetSearchModelsQuery({
+    lang: i18n.language,
+    urlState: {
+      domain: searchParams.groups ?? [],
+      lang: contentLanguage ?? i18n.language,
+      organization: '',
+      page: searchParams.pageFrom ?? 0,
+      q: searchParams.query,
+      status: searchParams.status ?? [],
+      type: '',
+      types:
+        applicationProfile && searchParams.limitToModelType
+          ? [searchParams.limitToModelType]
+          : ['LIBRARY'],
     },
-    { skip: searchParams.query === '' }
-  );
+  });
 
   const resetToInit = () => {
     setSearchParams({


### PR DESCRIPTION
Show search results in datamodel linking modal with empty search keyword. This way the user doesn't have to go through extra steps to get some datamodels listed.