### PR TITLE
YTI-3939 Checking that all references exist before releasing data model

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -269,6 +269,8 @@
   "release-errors-general-info": "There are incomplete resources in the data model. You can fix errors or continue publishing.",
   "release-missing-reference-to-library-info": "There are resources in the data model, which don't refer to any core data model resource",
   "release-missing-reference-to-library-title": "Reference to core data model",
+  "release-references-not-exist-title": "References to non existing resources",
+  "release-references-not-exist-info": "",
   "release-version-number": "Release version number",
   "release-version-number-hint": "Write version number for the release in format x.y.z (for example 1.1.0)",
   "remove": "Remove",

--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -269,7 +269,7 @@
   "release-errors-general-info": "There are incomplete resources in the data model. You can fix errors or continue publishing.",
   "release-missing-reference-to-library-info": "There are resources in the data model, which don't refer to any core data model resource",
   "release-missing-reference-to-library-title": "Reference to core data model",
-  "release-references-not-exist-title": "References to non existing resources",
+  "release-references-not-exist-title": "References to non-existing resources",
   "release-references-not-exist-info": "",
   "release-version-number": "Release version number",
   "release-version-number-hint": "Write version number for the release in format x.y.z (for example 1.1.0)",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -269,7 +269,7 @@
   "release-errors-general-info": "Tietomallissa on puutteellisia resursseja. Siirry korjaamaan viittaukset tai jatka julkaisua.",
   "release-missing-reference-to-library-info": "Tietomallissa on resursseja, jotka eivät viittaa mihinkään ydintietomalliin.",
   "release-missing-reference-to-library-title": "Viittaus ydintietomalliin",
-  "release-references-not-exist-title": "Viittauksia resurseihin, joita ei ole olemassa",
+  "release-references-not-exist-title": "Viittauksia resursseihin, joita ei ole olemassa",
   "release-references-not-exist-info": "",
   "release-version-number": "Tietomallin versionumero",
   "release-version-number-hint": "Kirjoita versionumero muodossa x.y.z (esimerkiksi 1.1.0)",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -269,6 +269,8 @@
   "release-errors-general-info": "Tietomallissa on puutteellisia resursseja. Siirry korjaamaan viittaukset tai jatka julkaisua.",
   "release-missing-reference-to-library-info": "Tietomallissa on resursseja, jotka eivät viittaa mihinkään ydintietomalliin.",
   "release-missing-reference-to-library-title": "Viittaus ydintietomalliin",
+  "release-references-not-exist-title": "Viittauksia resurseihin, joita ei ole olemassa",
+  "release-references-not-exist-info": "",
   "release-version-number": "Tietomallin versionumero",
   "release-version-number-hint": "Kirjoita versionumero muodossa x.y.z (esimerkiksi 1.1.0)",
   "remove": "Poista",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -269,6 +269,8 @@
   "release-errors-general-info": "",
   "release-missing-reference-to-library-info": "",
   "release-missing-reference-to-library-title": "",
+  "release-references-not-exist-title": "",
+  "release-references-not-exist-info": "",
   "release-version-number": "",
   "release-version-number-hint": "",
   "remove": "",

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -8,7 +8,7 @@ import {
 } from '@app/common/interfaces/model.interface';
 import { createSlice } from '@reduxjs/toolkit';
 import { AppState, AppThunk } from '@app/store';
-import { UriData } from '@app/common/interfaces/uri.interface';
+import { ResourceReferencesResult } from '@app/common/interfaces/resource-reference.interface';
 
 export const modelApi = createApi({
   reducerPath: 'modelApi',
@@ -107,9 +107,7 @@ export const modelApi = createApi({
       }),
     }),
     getValidationErrors: builder.query<
-      {
-        [key: string]: UriData[];
-      },
+      ResourceReferencesResult,
       { modelId: string }
     >({
       query: (value) => ({

--- a/datamodel-ui/src/common/interfaces/resource-reference.interface.ts
+++ b/datamodel-ui/src/common/interfaces/resource-reference.interface.ts
@@ -9,5 +9,6 @@ export interface ResourceReferencesResult {
 interface ResourceReference {
   resourceURI: UriData;
   property: string;
+  target: string;
   type: ResourceType;
 }

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -708,5 +708,9 @@ export function translateValidationError(key: string, t: TFunction) {
       return t('release-missing-reference-to-library-title', { ns: 'admin' });
     case 'missing-reference-to-library-info':
       return t('release-missing-reference-to-library-info', { ns: 'admin' });
+    case 'references-not-exist':
+      return t('release-references-not-exist-title', { ns: 'admin' });
+    case 'references-not-exist-info':
+      return t('release-references-not-exist-info', { ns: 'admin' });
   }
 }

--- a/datamodel-ui/src/modules/create-release-modal/index.tsx
+++ b/datamodel-ui/src/modules/create-release-modal/index.tsx
@@ -131,29 +131,31 @@ export default function CreateReleaseModal({
 
           <Text>{t('release-errors-general-info')}</Text>
 
-          {Object.entries(validationErrors).map(([key, resources]) => {
-            return (
-              <ReleaseValidationErrors key={key}>
-                <Heading variant="h4">
-                  {translateValidationError(key, t)}
-                </Heading>
-                <Text>{translateValidationError(`${key}-info`, t)}</Text>
-                <ul>
-                  {resources.map((resource) => (
-                    <li key={resource.resourceURI.uri}>
-                      <UriInfo
-                        uri={resource.resourceURI}
-                        lang={i18n.language}
-                      />
-                      <div style={{ fontSize: '14px' }}>
-                        {resource.property} = {resource.target}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </ReleaseValidationErrors>
-            );
-          })}
+          <ReleaseValidationErrors>
+            {Object.entries(validationErrors).map(([key, resources]) => {
+              return (
+                <>
+                  <Heading variant="h4">
+                    {translateValidationError(key, t)}
+                  </Heading>
+                  <Text>{translateValidationError(`${key}-info`, t)}</Text>
+                  <ul>
+                    {resources.map((resource) => (
+                      <li key={resource.resourceURI.uri}>
+                        <UriInfo
+                          uri={resource.resourceURI}
+                          lang={i18n.language}
+                        />
+                        <div style={{ fontSize: '14px' }}>
+                          {resource.property} = {resource.target}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              );
+            })}
+          </ReleaseValidationErrors>
           <ButtonFooter>
             <Button id="skip-errors-continue-button" onClick={handleContinue}>
               {t('continue')}

--- a/datamodel-ui/src/modules/create-release-modal/index.tsx
+++ b/datamodel-ui/src/modules/create-release-modal/index.tsx
@@ -139,9 +139,15 @@ export default function CreateReleaseModal({
                 </Heading>
                 <Text>{translateValidationError(`${key}-info`, t)}</Text>
                 <ul>
-                  {resources.map((uri) => (
-                    <li key={uri.uri}>
-                      <UriInfo uri={uri} lang={i18n.language} />
+                  {resources.map((resource) => (
+                    <li key={resource.resourceURI.uri}>
+                      <UriInfo
+                        uri={resource.resourceURI}
+                        lang={i18n.language}
+                      />
+                      <div style={{ fontSize: '14px' }}>
+                        {resource.property} = {resource.target}
+                      </div>
                     </li>
                   ))}
                 </ul>

--- a/datamodel-ui/src/modules/create-release-modal/release-model-styles.tsx
+++ b/datamodel-ui/src/modules/create-release-modal/release-model-styles.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const ReleaseValidationErrors = styled.div`
-  margin-top: 20px;
+  margin-top: 15px;
   overflow-y: auto;
   max-height: 300px;
 


### PR DESCRIPTION
- Before release, check that all references to current and external (other models in Interoperability platform) namespaces exists ([backend changes](https://github.com/VRK-YTI/yti-datamodel-api/pull/292)). 
- Change representation of invalid resources by using ResourceReference interface 

<img width="601" alt="Screenshot 2024-04-19 at 8 22 53" src="https://github.com/VRK-YTI/yti-ui/assets/16885816/9974332a-b0cd-4d8a-83fb-8632f52bfe7c">
