### PR TITLE
add support for JSON Schema export

### DIFF
--- a/datamodel-ui/src/modules/as-file-modal/index.tsx
+++ b/datamodel-ui/src/modules/as-file-modal/index.tsx
@@ -43,6 +43,7 @@ export default function AsFileModal({
   const fileTypes = ['JSON-LD', 'RDF', 'Turtle' /*'XML'*/];
   if (applicationProfile) {
     fileTypes.push('OpenAPI');
+    fileTypes.push('JSON Schema');
   }
 
   const [chosenFileType, setChosenFileType] = useState('JSON-LD');

--- a/datamodel-ui/src/pages/api/getModelAsFile.ts
+++ b/datamodel-ui/src/pages/api/getModelAsFile.ts
@@ -25,6 +25,10 @@ export default withIronSessionApiRoute(
         mimeType = 'application/vnd+oai+openapi+json';
         filename += '.json';
         break;
+      case 'JSONSchema':
+        mimeType = 'application/schema+json';
+        filename += '.schema.json';
+        break;
       case 'LD+JSON':
       default:
         mimeType = 'application/ld+json';


### PR DESCRIPTION
Add JSON Schema as an option for export

![image](https://github.com/VRK-YTI/yti-ui/assets/25614946/dfc3509a-08ce-49b1-a116-77734b9c284a)
