### PR TITLE
fix JSON Schema export not using the correct parameter

### DIFF
--- a/datamodel-ui/src/pages/api/getModelAsFile.ts
+++ b/datamodel-ui/src/pages/api/getModelAsFile.ts
@@ -25,7 +25,7 @@ export default withIronSessionApiRoute(
         mimeType = 'application/vnd+oai+openapi+json';
         filename += '.json';
         break;
-      case 'JSONSchema':
+      case 'JSON Schema':
         mimeType = 'application/schema+json';
         filename += '.schema.json';
         break;


### PR DESCRIPTION
The discrepancy with the parameter name for getModelAsFile caused JSON Schema export to do a JSON-LD export instead.

The parameter name should be the same as it is in the selection modal.