### PR TITLE
YTI-4042 Remove datamodels

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -170,6 +170,7 @@
     "deleting-class": "Removing class",
     "deleting-model": "Removing model",
     "model-description": "Remove model {{targetName}}",
+    "model-description-version": "Remove version {{targetVersion}} from model {{targetName}}?",
     "model-error": "An error occurrred while removing model {{targetName}}",
     "model-success": "Model {{targetName}} removed",
     "model-title": "Remove model"

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -170,6 +170,7 @@
     "deleting-class": "Poistetaan luokkaa",
     "deleting-model": "Poistetaan tietomallia",
     "model-description": "Haluatko poistaa tietomallin {{targetName}}?",
+    "model-description-version": "Haluatko poistaa version {{targetVersion}} tietomallista {{targetName}}?",
     "model-error": "Tietomallin {{targetName}} poistamisessa ilmeni ongelma",
     "model-success": "Tietomalli {{targetName}} poistettu",
     "model-title": "Poista tietomalli"

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -170,6 +170,7 @@
     "deleting-class": "",
     "deleting-model": "",
     "model-description": "",
+    "model-description-version": "",
     "model-error": "",
     "model-success": "",
     "model-title": ""

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -51,9 +51,14 @@ export const modelApi = createApi({
       }),
       invalidatesTags: ['Model'],
     }),
-    deleteModel: builder.mutation<string, string>({
+    deleteModel: builder.mutation<
+      string,
+      { modelId: string; version?: string }
+    >({
       query: (value) => ({
-        url: `/model/${value}`,
+        url: `/model/${value.modelId}${
+          value.version ? `?version=${value.version}` : ''
+        }`,
         method: 'DELETE',
       }),
     }),

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -261,14 +261,21 @@ export function translateDeleteModalTitle(
 export function translateDeleteModalDescription(
   type: 'model' | 'class' | 'association' | 'attribute',
   t: TFunction,
-  targetName?: string
+  targetName?: string,
+  targetVersion?: string
 ) {
   switch (type) {
     case 'model':
-      return t('delete-modal.model-description', {
-        ns: 'admin',
-        targetName: targetName,
-      });
+      return !targetVersion
+        ? t('delete-modal.model-description', {
+            ns: 'admin',
+            targetName: targetName,
+          })
+        : t('delete-modal.model-description-version', {
+            ns: 'admin',
+            targetName: targetName,
+            targetVersion: targetVersion,
+          });
     case 'class':
       return t('delete-modal.class-description', {
         ns: 'admin',

--- a/datamodel-ui/src/modules/delete-modal/index.tsx
+++ b/datamodel-ui/src/modules/delete-modal/index.tsx
@@ -23,6 +23,7 @@ import getApiError from '@app/common/utils/get-api-errors';
 
 interface DeleteModalProps {
   modelId: string;
+  modelVersion?: string;
   resourceId?: string;
   label: string;
   type: 'model' | 'class' | 'attribute' | 'association';
@@ -34,6 +35,7 @@ interface DeleteModalProps {
 
 export default function DeleteModal({
   modelId,
+  modelVersion,
   label,
   type,
   resourceId,
@@ -72,7 +74,7 @@ export default function DeleteModal({
   const handleDelete = () => {
     setUserPosted(true);
     if (type === 'model') {
-      deleteModel(modelId);
+      deleteModel({ modelId: modelId, version: modelVersion });
     } else if (type === 'class') {
       deleteClass({
         modelId: modelId,
@@ -129,7 +131,9 @@ export default function DeleteModal({
     return (
       <>
         <ModalTitle>{translateDeleteModalTitle(type, t)}</ModalTitle>
-        <Text>{translateDeleteModalDescription(type, t, label)}</Text>
+        <Text>
+          {translateDeleteModalDescription(type, t, label, modelVersion)}
+        </Text>
 
         <ButtonFooter>
           <Button

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -211,6 +211,13 @@ export default function ModelInfoView({
             ) : (
               <></>
             )}
+            {hasPermission && (user.superuser || !modelInfo.version) ? (
+              <ActionMenuItem onClick={() => handleModalChange('delete', true)}>
+                {t('remove', { ns: 'admin' })}
+              </ActionMenuItem>
+            ) : (
+              <></>
+            )}
             {hasPermission ? <ActionMenuDivider /> : <></>}
             <ActionMenuItem
               onClick={() => handleModalChange('showAsFile', true)}
@@ -409,6 +416,7 @@ export default function ModelInfoView({
               <>
                 <DeleteModal
                   modelId={modelId}
+                  modelVersion={version}
                   label={getLanguageVersion({
                     data: modelInfo.label,
                     lang: i18n.language,

--- a/datamodel-ui/src/modules/resource/resource-form/components/association-restrictions.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/association-restrictions.tsx
@@ -99,6 +99,7 @@ export default function AssociationRestrictions({
               }
               initialSelected={data.classType?.uri}
               applicationProfile
+              limitToModelType="LIBRARY"
             />
           }
           handleRemoval={() => handleUpdate('classType', undefined)}


### PR DESCRIPTION
Enable removing data models from the UI. In draft models remove button is always visible if user has permissions. In versioned data models the button is visible only for superusers. 

Backend changes: https://github.com/VRK-YTI/yti-datamodel-api/pull/298

Other bug fix: Fix selecting association's target class (sh:class). Only library class is allowed to select.