### PR TITLE
YTI-4025 Visualization fixes

### DIFF
--- a/datamodel-ui/src/common/interfaces/resource-reference.interface.ts
+++ b/datamodel-ui/src/common/interfaces/resource-reference.interface.ts
@@ -1,5 +1,4 @@
 import { ResourceType } from './resource-type.interface';
-import { Type } from './type.interface';
 import { UriData } from './uri.interface';
 
 export interface ResourceReferencesResult {

--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -42,7 +42,7 @@ export interface VisualizationPutType {
   identifier: string;
   x: number;
   y: number;
-  referenceTargets: string[];
+  referenceTargets?: ReferenceTarget[];
 }
 
 export interface VisualizationHiddenNode {
@@ -59,4 +59,9 @@ export interface VisualizationHiddenNode {
 export interface VisualizationResult {
   nodes: VisualizationType[];
   hiddenNodes: VisualizationHiddenNode[];
+}
+
+export interface ReferenceTarget {
+  target: string;
+  origin: string;
 }

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -530,7 +530,9 @@ export default function ClassInfo({
                 handleFollowUp={handleFollowUp}
                 applicationProfile={applicationProfile}
                 limitToSelect={!applicationProfile}
-                hiddenResources={data.association?.map((assoc) => assoc.uri)}
+                hiddenResources={data.association
+                  ?.filter((assoc) => !assoc.range)
+                  .map((assoc) => assoc.uri)}
               />
             </div>
           ) : (

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -14,8 +14,11 @@ import { useEffect, useRef, useState } from 'react';
 import { SearchInput, Text } from 'suomifi-ui-components';
 import ClassForm from '../class-form';
 import ClassModal from '../class-modal';
-import { classTypeToClassForm, internalClassToClassForm } from './utils';
-import { OWL_THING } from './utils';
+import {
+  classTypeToClassForm,
+  internalClassToClassForm,
+  OWL_THING,
+} from './utils';
 import DrawerItemList from '@app/common/components/drawer-item-list';
 import StaticHeader from 'yti-common-ui/drawer/static-header';
 import DrawerContent from 'yti-common-ui/drawer/drawer-content-wrapper';

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -9,7 +9,6 @@ import {
   ReactFlowProvider,
   useReactFlow,
   Node,
-  useStoreApi,
 } from 'reactflow';
 import {
   useGetVisualizationQuery,
@@ -88,9 +87,6 @@ const GraphContent = ({
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [cleanUnusedCorners, setCleanUnusedCorners] = useState(false);
-  const store = useStoreApi();
-  const { addSelectedNodes } = store.getState();
-
   const nodeTypes: NodeTypes = useMemo(
     () => ({
       classNode: ClassNode,

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -9,6 +9,7 @@ import {
   ReactFlowProvider,
   useReactFlow,
   Node,
+  useStoreApi,
 } from 'reactflow';
 import {
   useGetVisualizationQuery,
@@ -87,6 +88,9 @@ const GraphContent = ({
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [cleanUnusedCorners, setCleanUnusedCorners] = useState(false);
+  const store = useStoreApi();
+  const { addSelectedNodes } = store.getState();
+
   const nodeTypes: NodeTypes = useMemo(
     () => ({
       classNode: ClassNode,
@@ -126,7 +130,8 @@ const GraphContent = ({
       target: string,
       x: number,
       y: number,
-      referenceType: ReferenceType
+      referenceType: ReferenceType,
+      origin: string
     ) => {
       const { top, left } = reactFlowWrapper.current
         ? reactFlowWrapper.current.getBoundingClientRect()
@@ -142,6 +147,7 @@ const GraphContent = ({
         referenceType,
         source,
         target,
+        origin,
         deleteNodeById,
         setEdges,
         setNodes,
@@ -168,7 +174,8 @@ const GraphContent = ({
         edge.target,
         e.clientX,
         e.clientY,
-        edge.referenceType
+        edge.referenceType,
+        edge.data.origin
       );
       dispatch(setGraphHasChanges(true));
     },
@@ -428,6 +435,8 @@ const GraphContent = ({
   return (
     <FlowWrapper ref={reactFlowWrapper} $isSmall={isSmall}>
       <ModelFlow
+        snapToGrid
+        snapGrid={[10, 10]}
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -181,6 +181,7 @@ export default function convertToEdges(
                   identifier: assoc.identifier,
                   params: getEdgeParams(firstCornerNodeId, assoc),
                   applicationProfile,
+                  origin: assoc.identifier,
                 });
               }
 
@@ -278,20 +279,23 @@ export default function convertToEdges(
             identifier: reference.identifier,
             params: getEdgeParams(firstCornerNodeId, reference),
             applicationProfile,
+            origin: node.identifier,
           });
         }
+
+        const edgeIdentifier = ['ATTRIBUTE_DOMAIN', 'PARENT_CLASS'].includes(
+          reference.referenceType
+        )
+          ? node.identifier
+          : reference.identifier;
 
         return createEdge({
           modelId: modelId,
           label: label,
-          identifier: ['ATTRIBUTE_DOMAIN', 'PARENT_CLASS'].includes(
-            reference.referenceType
-          )
-            ? node.identifier
-            : reference.identifier,
+          identifier: edgeIdentifier,
           params: getEdgeParams(node.identifier, reference),
           applicationProfile,
-          origin: node.identifier,
+          origin: edgeIdentifier,
         });
       }),
     ]);

--- a/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
@@ -70,11 +70,17 @@ describe('generate-positions-payload', () => {
           id: 'edge-1-corner-1',
           source: 'node-1',
           target: '#corner-1',
+          data: {
+            origin: 'assoc-1',
+          },
         },
         {
           id: 'edge-corner-1-2',
           source: '#corner-1',
           target: 'node-2',
+          data: {
+            origin: 'assoc-1',
+          },
         },
       ]
     );
@@ -82,7 +88,12 @@ describe('generate-positions-payload', () => {
     expect(returned).toStrictEqual([
       {
         identifier: 'node-1',
-        referenceTargets: ['corner-1'],
+        referenceTargets: [
+          {
+            target: 'corner-1',
+            origin: 'assoc-1',
+          },
+        ],
         x: 0,
         y: 0,
       },
@@ -100,7 +111,12 @@ describe('generate-positions-payload', () => {
       },
       {
         identifier: 'corner-1',
-        referenceTargets: ['node-2'],
+        referenceTargets: [
+          {
+            target: 'node-2',
+            origin: 'assoc-1',
+          },
+        ],
         x: 25,
         y: 25,
       },

--- a/datamodel-ui/src/modules/graph/utils/generate-positions-payload/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/generate-positions-payload/index.ts
@@ -3,7 +3,10 @@ import {
   CornerNodeDataType,
   EdgeDataType,
 } from '@app/common/interfaces/graph.interface';
-import { VisualizationPutType } from '@app/common/interfaces/visualization.interface';
+import {
+  ReferenceTarget,
+  VisualizationPutType,
+} from '@app/common/interfaces/visualization.interface';
 import { Edge, Node } from 'reactflow';
 
 export default function generatePositionsPayload(
@@ -23,10 +26,13 @@ export default function generatePositionsPayload(
           (edge.source.startsWith('#corner') &&
             !edge.target.startsWith('#corner'))
         ) {
-          return cleanCornerIdentifier(edge.target);
+          return {
+            target: cleanCornerIdentifier(edge.target),
+            origin: edge.data?.origin,
+          };
         }
       })
-      .filter((value) => typeof value === 'string' && value !== '') as string[];
+      .filter((value) => value && value.target) as ReferenceTarget[];
 
     return {
       identifier: cleanCornerIdentifier(node.id),

--- a/datamodel-ui/src/modules/graph/utils/graph-utils/index.tsx
+++ b/datamodel-ui/src/modules/graph/utils/graph-utils/index.tsx
@@ -13,6 +13,7 @@ export function splitEdgeFn({
   referenceType,
   source,
   target,
+  origin,
   deleteNodeById,
   setEdges,
   setNodes,
@@ -26,6 +27,7 @@ export function splitEdgeFn({
   referenceType: ReferenceType;
   source: string;
   target: string;
+  origin: string;
   deleteNodeById: (value: string) => void;
   setEdges: (edges: SetStateAction<Edge[]>) => void;
   setNodes: (nodes: SetStateAction<Node[]>) => void;
@@ -56,6 +58,7 @@ export function splitEdgeFn({
       },
       isCorner: true,
       applicationProfile,
+      origin: origin,
     }),
   ];
 
@@ -72,6 +75,7 @@ export function splitEdgeFn({
         },
         isCorner: true,
         applicationProfile,
+        origin: origin,
       })
     );
   }
@@ -82,6 +86,7 @@ export function splitEdgeFn({
         if (
           edge.target === target &&
           edge.source === source &&
+          edge.data.origin === origin &&
           !target.includes('corner') &&
           !edge.target.includes('corner')
         ) {
@@ -95,7 +100,14 @@ export function splitEdgeFn({
 
         return edge;
       })
-      .filter((edge) => !(edge.source === source && edge.target === target)),
+      .filter(
+        (edge) =>
+          !(
+            edge.source === source &&
+            edge.target === target &&
+            edge.data.origin === origin
+          )
+      ),
     ...newEdges,
   ]);
 }

--- a/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
@@ -309,7 +309,7 @@ export const expectedLibraryEdges = {
         label: { fi: 'onOsoite' },
         identifier: 'is-address',
         modelId: 'modelId',
-        origin: 'person',
+        origin: 'is-address',
       },
     },
     {

--- a/datamodel-ui/src/modules/resource/utils.ts
+++ b/datamodel-ui/src/modules/resource/utils.ts
@@ -1,5 +1,4 @@
 import { ResourceFormType } from '@app/common/interfaces/resource-form.interface';
-import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { Resource } from '@app/common/interfaces/resource.interface';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import { v4 } from 'uuid';


### PR DESCRIPTION
- Send corner node origin to backend. 
- Enable snapToGrid feature

Other fixes:
- Remove unused imports 
- Class add association modal: Allow select association which already added to the class if there is also range added