### PR TITLE
YTI-4074 redirect v1 application URLs

### DIFF
--- a/datamodel-ui/next.config.js
+++ b/datamodel-ui/next.config.js
@@ -20,6 +20,7 @@ module.exports = () => {
     },
     i18n,
     transpilePackages: ['common-ui'],
+    skipTrailingSlashRedirect: true,
     async headers() {
       const isProd = process.env.NODE_ENV === 'production';
       const matomoUrl = process.env.MATOMO_URL ?? '';
@@ -92,6 +93,15 @@ module.exports = () => {
       async rewrites() {
         return [
           {
+            source: '/model/:modelId/:resourceId/',
+            destination:
+              '/api/v1-redirect?modelId=:modelId&resourceId=:resourceId',
+          },
+          {
+            source: '/model/:modelId/',
+            destination: '/api/v1-redirect?modelId=:modelId',
+          },
+          {
             source: '/datamodel-api/:path*',
             destination: 'http://localhost:9004/datamodel-api/:path*',
           },
@@ -120,6 +130,15 @@ module.exports = () => {
       // https://nextjs.org/docs/api-reference/next.config.js/rewrites
       async rewrites() {
         return [
+          {
+            source: '/model/:modelId/:resourceId/',
+            destination:
+              '/api/v1-redirect?modelId=:modelId&resourceId=:resourceId',
+          },
+          {
+            source: '/model/:modelId/',
+            destination: '/api/v1-redirect?modelId=:modelId',
+          },
           {
             source: '/datamodel-api/:path*',
             destination: 'http://yti-datamodel-api:9004/datamodel-api/:path*',

--- a/datamodel-ui/src/pages/api/v1-redirect.ts
+++ b/datamodel-ui/src/pages/api/v1-redirect.ts
@@ -1,0 +1,68 @@
+import { userCookieOptions } from '@app/common/utils/user-cookie-options';
+import axios, { RawAxiosRequestHeaders } from 'axios';
+import { withIronSessionApiRoute } from 'iron-session/next';
+
+export default withIronSessionApiRoute(
+  async function redirect(req, res) {
+    const modelId = req.query['modelId'];
+    const resourceId = req.query['resourceId'];
+
+    if (!modelId) {
+      res.redirect('/');
+      return;
+    }
+
+    const headers: RawAxiosRequestHeaders = {};
+
+    const forwardedFor = req.headers['x-forwarded-for'] as string;
+    if (forwardedFor) {
+      headers['x-forwarded-for'] = forwardedFor;
+    }
+    const host = req.headers['host'] as string;
+    if (host) {
+      headers['host'] = host;
+    }
+
+    const sessionCookies = req.session.cookies ?? {};
+
+    const cookieString = Object.entries(sessionCookies)
+      .map(([key, value]) => {
+        if (key.toLowerCase() === 'jsessionid') {
+          return `JSESSIONID=${value}`;
+        } else if (key.toLowerCase().startsWith('_shibsession')) {
+          return `${key}=${value}`;
+        }
+      })
+      .filter(Boolean)
+      .join('; ');
+
+    headers['Cookie'] = cookieString;
+
+    const apiUrl =
+      process.env.AWS_ENV === 'local'
+        ? process.env.DATAMODEL_API_URL
+        : `${process.env.AUTH_PROXY_URL}/datamodel-api`;
+
+    // redirect based on location header
+    try {
+      const result = await axios.get(
+        `${apiUrl}/v2/resolve/v1?modelId=${modelId}${
+          resourceId ? `&resourceId=${resourceId}` : ''
+        }`,
+        {
+          maxRedirects: 0,
+          validateStatus: () => true,
+          headers: headers,
+        }
+      );
+
+      const redirectUrl = result.headers['location'];
+      res.redirect(redirectUrl ?? '/');
+    } catch (e) {
+      res.redirect('/');
+    }
+  },
+  {
+    ...userCookieOptions,
+  }
+);


### PR DESCRIPTION
Create a new rewrite config for v1 URLs (ending with slash)
- /model/model-id/ -> /api/v1-redirect?modelId=model-id
- /model/model-id/resource-id/ -> /api/v1-redirect?modelId=model-id&resourceId=resourceId

In `v1-redirect` route add headers needed and call endpoint for getting redirect address (see [backend implementation](https://github.com/VRK-YTI/yti-datamodel-api/pull/306))
