### PR TITLE
remove manual refetching in favor of cache invalidation

### DIFF
--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -119,6 +119,7 @@ export const resourceApi = createApi({
         url: `/class/toggle-deactivate/${props.modelId}?propertyUri=${props.uri}`,
         method: 'PUT',
       }),
+      invalidatesTags: ['Resource'],
     }),
     makeLocalCopyPropertyShape: builder.mutation<
       null,

--- a/datamodel-ui/src/common/interfaces/graph.interface.ts
+++ b/datamodel-ui/src/common/interfaces/graph.interface.ts
@@ -17,7 +17,6 @@ export interface ClassNodeDataType {
     minCount?: number | null;
   }[];
   organizationIds?: string[];
-  refetch?: () => void;
 }
 
 export interface AttributeNodeType {
@@ -26,7 +25,6 @@ export interface AttributeNodeType {
   uri: string;
   modelId: string;
   dataType?: string;
-  refetch?: () => void;
 }
 
 export interface CornerNodeDataType {

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -102,16 +102,11 @@ const GraphContent = ({
     }),
     []
   );
-  const { data, isFetching, isSuccess, refetch } = useGetVisualizationQuery({
+  const { data, isFetching, isSuccess } = useGetVisualizationQuery({
     modelid: modelId,
     version: version,
   });
   const [putPositions, result] = usePutPositionsMutation();
-
-  const refetchNodes = useCallback(() => {
-    refetch();
-    dispatch(setGraphHasChanges(false));
-  }, [refetch, dispatch]);
 
   const deleteNodeById = useCallback(
     (id: string) => {
@@ -251,7 +246,6 @@ const GraphContent = ({
         modelId,
         deleteNodeById,
         applicationProfile,
-        refetchNodes,
         organizationIds
       ),
       ...(loopNodes ? loopNodes : []),
@@ -269,7 +263,6 @@ const GraphContent = ({
     dispatch,
     modelId,
     organizationIds,
-    refetchNodes,
     resetPosition,
     setEdges,
     setNodes,
@@ -312,7 +305,6 @@ const GraphContent = ({
             modelId,
             deleteNodeById,
             applicationProfile,
-            refetchNodes,
             organizationIds
           ),
           ...(loopNodes ? loopNodes : []),
@@ -332,7 +324,6 @@ const GraphContent = ({
     dispatch,
     modelId,
     organizationIds,
-    refetchNodes,
     resetPosition,
     setEdges,
     setNodes,
@@ -412,12 +403,6 @@ const GraphContent = ({
       setCleanUnusedCorners(false);
     }
   }, [cleanUnusedCorners, edges, nodes, setNodes]);
-
-  useEffect(() => {
-    if (updateVisualization) {
-      refetchNodes();
-    }
-  }, [updateVisualization, refetchNodes, dispatch]);
 
   useEffect(() => {
     if (resetPosition) {

--- a/datamodel-ui/src/modules/graph/utils/convert-to-nodes/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-nodes/index.ts
@@ -12,19 +12,12 @@ const getNodeByType = (
   node: VisualizationType,
   modelId: string,
   applicationProfile?: boolean,
-  refetch?: () => void,
   organizationIds?: string[]
 ) => {
   if (node.type === 'CLASS') {
-    return createClassNode(
-      node,
-      modelId,
-      applicationProfile,
-      refetch,
-      organizationIds
-    );
+    return createClassNode(node, modelId, applicationProfile, organizationIds);
   } else if (node.type === 'ATTRIBUTE') {
-    return createAttributeNode(node, modelId, refetch);
+    return createAttributeNode(node, modelId);
   } else {
     return createExternalNode(node, applicationProfile);
   }
@@ -37,7 +30,6 @@ export function updateNodes(
   modelId: string,
   handleNodeDelete: (id: string) => void,
   applicationProfile?: boolean,
-  refetch?: () => void,
   organizationIds?: string[]
 ): Node[] {
   const mappedNodes = convertToNodes(
@@ -46,7 +38,6 @@ export function updateNodes(
     modelId,
     handleNodeDelete,
     applicationProfile,
-    refetch,
     organizationIds
   );
 
@@ -70,7 +61,6 @@ export default function convertToNodes(
   modelId: string,
   handleNodeDelete: (id: string) => void,
   applicationProfile?: boolean,
-  refetch?: () => void,
   organizationIds?: string[]
 ): Node[] {
   if (!nodes || nodes.length < 1) {
@@ -79,13 +69,13 @@ export default function convertToNodes(
 
   if (!hiddenNodes || hiddenNodes.length < 1) {
     return nodes.map((node) =>
-      getNodeByType(node, modelId, applicationProfile, refetch, organizationIds)
+      getNodeByType(node, modelId, applicationProfile, organizationIds)
     );
   }
 
   return [
     ...nodes.map((node) =>
-      getNodeByType(node, modelId, applicationProfile, refetch, organizationIds)
+      getNodeByType(node, modelId, applicationProfile, organizationIds)
     ),
     ...hiddenNodes.map((node) =>
       createCornerNode(node, handleNodeDelete, applicationProfile)

--- a/datamodel-ui/src/modules/graph/utils/create-attribute-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-attribute-node/index.ts
@@ -4,8 +4,7 @@ import { Node } from 'reactflow';
 
 export default function createAttributeNode(
   node: VisualizationType,
-  modelId: string,
-  refetch?: () => void
+  modelId: string
 ): Node<AttributeNodeType> {
   return {
     id: node.identifier,
@@ -16,7 +15,6 @@ export default function createAttributeNode(
       label: node.label,
       uri: node.uri,
       dataType: node.dataType,
-      ...(refetch ? { refetch: refetch } : {}),
     },
     type: 'attributeNode',
   };

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
@@ -7,7 +7,6 @@ export default function createClassNode(
   node: VisualizationType,
   modelId: string,
   applicationProfile?: boolean,
-  refetch?: () => void,
   organizationIds?: string[]
 ): Node<ClassNodeDataType> {
   return {
@@ -38,7 +37,6 @@ export default function createClassNode(
       ...(typeof organizationIds !== 'undefined'
         ? { organizationIds: organizationIds }
         : undefined),
-      ...(refetch ? { refetch: refetch } : {}),
     },
     type: 'classNode',
   };

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -95,11 +95,7 @@ export default function ResourceView({
     fromVersion: version,
   });
 
-  const {
-    data: resourceData,
-    refetch: refetchResource,
-    isError: resourceIsError,
-  } = useGetResourceQuery(
+  const { data: resourceData, isError: resourceIsError } = useGetResourceQuery(
     {
       modelId: globalSelected.modelId ?? modelId,
       resourceIdentifier: globalSelected.id ?? '',
@@ -113,7 +109,7 @@ export default function ResourceView({
     }
   );
 
-  const { data: inUse, refetch: refetchInUse } = useGetResourceActiveQuery(
+  const { data: inUse } = useGetResourceActiveQuery(
     {
       prefix: modelId,
       uri: `${SUOMI_FI_NAMESPACE}${globalSelected.modelId}/${globalSelected.id}`,
@@ -349,7 +345,6 @@ export default function ResourceView({
         handleEdit={handleEdit}
         handleReturn={handleReturn}
         handleShowResource={handleShowResource}
-        handleRefetch={refetchInUse}
         isPartOfCurrentModel={globalSelected.modelId === modelId}
         applicationProfile={applicationProfile}
         currentModelId={
@@ -374,10 +369,6 @@ export default function ResourceView({
         applicationProfile={applicationProfile}
         currentModelId={modelId}
         isEdit={view.edit}
-        refetch={() => {
-          refetchResource();
-          refetchInUse();
-        }}
         handleReturn={view.edit ? handleFormReturn : handleReturn}
       />
     );

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -68,7 +68,6 @@ interface ResourceFormProps {
   isEdit?: boolean;
   currentModelId: string;
   applicationProfile?: boolean;
-  refetch?: () => void;
   handleReturn: () => void;
   handleFollowUp?: (identifier: string, type: ResourceType) => void;
 }
@@ -80,7 +79,6 @@ export default function ResourceForm({
   isEdit,
   currentModelId,
   applicationProfile,
-  refetch,
   handleReturn,
   handleFollowUp,
 }: ResourceFormProps) {
@@ -314,10 +312,6 @@ export default function ResourceForm({
         data.identifier
       );
 
-      if (isEdit && refetch) {
-        refetch();
-      }
-
       router.replace(
         `${modelId}/${
           data.type === ResourceType.ASSOCIATION ? 'association' : 'attribute'
@@ -349,7 +343,6 @@ export default function ResourceForm({
     router,
     modelId,
     data,
-    refetch,
     isEdit,
     setView,
   ]);

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -44,7 +44,6 @@ interface CommonViewProps {
   handleReturn: () => void;
   handleShowResource: (id: string, modelPrefix: string) => void;
   handleEdit: () => void;
-  handleRefetch: () => void;
   isPartOfCurrentModel: boolean;
   applicationProfile?: boolean;
   currentModelId?: string;
@@ -59,7 +58,6 @@ export default function ResourceInfo({
   handleReturn,
   handleShowResource,
   handleEdit,
-  handleRefetch,
   isPartOfCurrentModel,
   applicationProfile,
   currentModelId,
@@ -106,12 +104,6 @@ export default function ResourceInfo({
   useEffect(() => {
     setExternalActive(inUse);
   }, [inUse]);
-
-  useEffect(() => {
-    if (toggleResult.isSuccess) {
-      handleRefetch();
-    }
-  }, [toggleResult, handleRefetch]);
 
   return (
     <>


### PR DESCRIPTION
Cache tags should already exists for all API operations, which should let RTK handle re-fetching automatically.

This hopefully fixes some errors caused by manual refetching, _"Error: Cannot refetch a query that has not been started yet."._

https://redux-toolkit.js.org/rtk-query/usage/automated-refetching

Needs to be tested more before turning this Draft into PR.