### PR TITLE
YTI-4137 add code lists for library class' attributes

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -87,6 +87,9 @@
   "codelist": "Code list",
   "codelist-contents": "Code list contents",
   "codelist-delete-warning": "Are you sure you want to delete codelist {{name}}. Codes in codelist will also be removed from other fields.",
+  "codelist-remove-confirm": "Are you sure you want to delete codelist?",
+  "codelist-added": "Code list added",
+  "codelist-removed": "Code list removed",
   "commentable-version": "commentable version",
   "common-form": {
     "add-equivalent-association": "Add equivelant association",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -87,6 +87,9 @@
   "codelist": "Koodisto",
   "codelist-contents": "Koodiston sisältö",
   "codelist-delete-warning": "Haluatko poistaa koodiston {{name}}. Koodistosta valitut arvot poistetaan myös muista kentistä.",
+  "codelist-remove-confirm": "Haluatko poistaa koodiston {{name}}?",
+  "codelist-added": "Koodisto lisätty",
+  "codelist-removed": "Koodisto poistettu",
   "commentable-version": "Kommentoitava versio",
   "common-form": {
     "add-equivalent-association": "Lisää vastaava assosiaatio",

--- a/datamodel-ui/src/common/components/class/class.slice.tsx
+++ b/datamodel-ui/src/common/components/class/class.slice.tsx
@@ -183,6 +183,44 @@ export const classApi = createApi({
       }),
       invalidatesTags: ['Class'],
     }),
+    addCodeList: builder.mutation<
+      string,
+      {
+        prefix: string;
+        classIdentifier: string;
+        attributeUri: string;
+        codeLists: string[];
+      }
+    >({
+      query: (value) => ({
+        url: `/class/library/${value.prefix}/${value.classIdentifier}/codeList`,
+        data: {
+          attributeUri: value.attributeUri,
+          codeLists: value.codeLists,
+        },
+        method: 'PUT',
+      }),
+      invalidatesTags: ['Class'],
+    }),
+    removeCodeList: builder.mutation<
+      string,
+      {
+        prefix: string;
+        classIdentifier: string;
+        attributeUri: string;
+        codeList: string;
+      }
+    >({
+      query: (value) => ({
+        url: `/class/library/${value.prefix}/${value.classIdentifier}/codeList`,
+        params: {
+          attributeUri: value.attributeUri,
+          codeListUri: value.codeList,
+        },
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Class'],
+    }),
   }),
 });
 
@@ -222,6 +260,8 @@ export const {
   useDeletePropertyReferenceMutation,
   useRenameClassMutation,
   useUpdateClassResrictionTargetMutation,
+  useAddCodeListMutation,
+  useRemoveCodeListMutation,
   util: { getRunningQueriesThunk },
 } = classApi;
 

--- a/datamodel-ui/src/common/interfaces/notifications.interface.ts
+++ b/datamodel-ui/src/common/interfaces/notifications.interface.ts
@@ -18,4 +18,6 @@ export type NotificationKeys =
   | 'POSITION_SAVE'
   | 'SUBSCRIPTION_ADD'
   | 'SUBSCRIPTION_DELETE'
-  | 'REQUEST_ADD';
+  | 'REQUEST_ADD'
+  | 'CODE_LIST_ADDED'
+  | 'CODE_LIST_REMOVED';

--- a/datamodel-ui/src/common/interfaces/simple-resource.interface.ts
+++ b/datamodel-ui/src/common/interfaces/simple-resource.interface.ts
@@ -14,4 +14,5 @@ export interface SimpleResource {
   version?: string;
   versionIri?: string;
   range?: UriData;
+  codeLists?: string[];
 }

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -559,6 +559,10 @@ export function translateNotification(
       return t('email-subscriptions-off', { ns: 'common' });
     case 'REQUEST_ADD':
       return t('access-request-sent', { ns: 'common' });
+    case 'CODE_LIST_ADDED':
+      return t('codelist-added', { ns: 'admin' });
+    case 'CODE_LIST_REMOVED':
+      return t('codelist-removed', { ns: 'admin' });
     default:
       return '';
   }

--- a/datamodel-ui/src/modules/class-view/remove-code-list-modal.tsx
+++ b/datamodel-ui/src/modules/class-view/remove-code-list-modal.tsx
@@ -1,0 +1,99 @@
+import { Button, InlineAlert, ModalTitle, Text } from 'suomifi-ui-components';
+import {
+  ButtonFooter,
+  NarrowModal,
+  SimpleModalContent,
+} from '../as-file-modal/as-file-modal.styles';
+import { useEffect, useState } from 'react';
+import { useBreakpoints } from 'yti-common-ui/media-query';
+import { useTranslation } from 'react-i18next';
+import { useRemoveCodeListMutation } from '@app/common/components/class/class.slice';
+import getApiError from '@app/common/utils/get-api-errors';
+import { setNotification } from '@app/common/components/notifications/notifications.slice';
+import { useStoreDispatch } from '@app/store';
+
+interface RemoveCodeListModalProps {
+  codeList?: string;
+  modelId: string;
+  classId: string;
+  attributeUri: string;
+  showModal: boolean;
+  setShowModal: (open: boolean) => void;
+}
+
+export default function RemoveCodeListModal({
+  modelId,
+  classId,
+  attributeUri,
+  showModal,
+  codeList,
+  setShowModal,
+}: RemoveCodeListModalProps) {
+  const [removeCodeList, removeCodeListResult] = useRemoveCodeListMutation();
+
+  const { t } = useTranslation('admin');
+  const { isSmall } = useBreakpoints();
+  const [error, setError] = useState(false);
+  const dispatch = useStoreDispatch();
+
+  const handleClose = () => {
+    setError(false);
+    setShowModal(false);
+  };
+
+  const handleRemoveCodeList = (codeList: string) => {
+    removeCodeList({
+      prefix: modelId,
+      classIdentifier: classId,
+      attributeUri: attributeUri,
+      codeList: codeList,
+    });
+  };
+
+  useEffect(() => {
+    if (removeCodeListResult.isSuccess) {
+      setShowModal(false);
+      dispatch(setNotification('CODE_LIST_REMOVED'));
+    } else if (removeCodeListResult.isError) {
+      setError(true);
+    }
+  }, [removeCodeListResult]);
+
+  if (!codeList) {
+    return <></>;
+  }
+
+  return (
+    <NarrowModal
+      appElementId="__next"
+      visible={showModal}
+      variant={isSmall ? 'smallScreen' : 'default'}
+      onEscKeyDown={handleClose}
+    >
+      <SimpleModalContent>
+        <ModalTitle>{t('delete-codelist')}</ModalTitle>
+        <Text>
+          {t('codelist-remove-confirm', {
+            name: codeList,
+          })}
+        </Text>
+        {removeCodeListResult.error && error && (
+          <InlineAlert status="error">
+            {getApiError(removeCodeListResult.error)[0]}
+          </InlineAlert>
+        )}
+        <ButtonFooter>
+          <Button
+            onClick={() => handleRemoveCodeList(codeList)}
+            id="delete-button"
+          >
+            {t('remove')}
+          </Button>
+          <Button variant="secondary" onClick={handleClose} id="cancel-button">
+            {t('cancel-variant')}
+          </Button>
+        </ButtonFooter>
+      </SimpleModalContent>
+    </NarrowModal>
+  );
+}

--- a/datamodel-ui/src/modules/code-list-modal/index.tsx
+++ b/datamodel-ui/src/modules/code-list-modal/index.tsx
@@ -34,12 +34,18 @@ export default function CodeListModal({
   modalTitle,
   showConfirmModal,
   setData,
+  hideAddButton,
+  isOpen,
+  setOpen,
 }: {
   initialData: ModelCodeList[];
   extendedView?: boolean;
   showConfirmModal?: boolean;
   modalTitle?: string;
   setData: (value: ModelCodeList[]) => void;
+  hideAddButton?: boolean;
+  isOpen?: boolean;
+  setOpen?: (open: boolean) => void;
 }) {
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -49,7 +55,14 @@ export default function CodeListModal({
   const handleClose = () => {
     setVisible(false);
     setConfirmed(false);
+    if (setOpen) {
+      setOpen(false);
+    }
   };
+
+  useEffect(() => {
+    setVisible(isOpen ? isOpen : false);
+  }, [isOpen]);
 
   const renderConfirmModal = () => (
     <NarrowModal
@@ -112,15 +125,18 @@ export default function CodeListModal({
 
   return (
     <>
-      <Button
-        variant="secondary"
-        icon={<IconPlus />}
-        onClick={() => setVisible(true)}
-        id="add-reference-data-button"
-      >
-        {t('add-reference-data')}
-      </Button>
-
+      {hideAddButton ? (
+        <></>
+      ) : (
+        <Button
+          variant="secondary"
+          icon={<IconPlus />}
+          onClick={() => setVisible(true)}
+          id="add-reference-data-button"
+        >
+          {t('add-reference-data')}
+        </Button>
+      )}
       {showConfirmModal && !confirmed && renderConfirmModal()}
       {(confirmed || !showConfirmModal) && extendedView && renderWideModal()}
       {(confirmed || !showConfirmModal) && !extendedView && renderModal()}

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -13,6 +13,7 @@ import {
   ExpanderTitleButton,
   ExternalLink,
   IconCopy,
+  IconRemove,
   Link,
   Text,
 } from 'suomifi-ui-components';
@@ -48,6 +49,9 @@ export default function CommonViewContent({
   handleChangeTarget,
   targetInClassRestriction,
   organizationIds,
+  simpleResourceCodeLists,
+  disableEdit,
+  handleRemoveCodeList,
 }: {
   modelId: string;
   inUse?: boolean;
@@ -59,6 +63,9 @@ export default function CommonViewContent({
   handleChangeTarget?: (value?: InternalClassInfo) => void;
   targetInClassRestriction?: UriData;
   organizationIds?: string[];
+  simpleResourceCodeLists?: string[];
+  disableEdit?: boolean;
+  handleRemoveCodeList?: (value: string) => void;
 }) {
   const { t, i18n } = useTranslation('common');
   const hasPermission = HasPermission({
@@ -363,6 +370,39 @@ export default function CommonViewContent({
       <>
         {data.type === ResourceType.ATTRIBUTE && (
           <>
+            <BasicBlock title={t('codelist', { ns: 'admin' })}>
+              {simpleResourceCodeLists && simpleResourceCodeLists.length > 0
+                ? simpleResourceCodeLists.map((codeList) => (
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                      }}
+                      key={codeList}
+                    >
+                      <Text style={{ marginTop: '5px' }}>
+                        <Link
+                          key={codeList}
+                          href={`${codeList}${getEnvParam(codeList, true)}`}
+                        >
+                          {codeList.split('/').slice(-2).join(':')}
+                        </Link>
+                      </Text>
+                      {hasPermission &&
+                        !disableEdit &&
+                        handleRemoveCodeList && (
+                          <Button
+                            icon={<IconRemove />}
+                            variant="secondaryNoBorder"
+                            onClick={() => handleRemoveCodeList(codeList)}
+                          >
+                            {t('remove')}
+                          </Button>
+                        )}
+                    </div>
+                  ))
+                : t('not-defined')}
+            </BasicBlock>
             <BasicBlock
               title={t('data-type')}
               tooltip={{
@@ -546,24 +586,26 @@ export default function CommonViewContent({
               title={t('association-target-in-this-class', { ns: 'admin' })}
               largeGap
               extra={
-                <div
-                  style={{
-                    width: 'max-content',
-                  }}
-                >
-                  <ClassModal
-                    modalButtonLabel={t('choose-association-target', {
-                      ns: 'admin',
-                    })}
-                    mode="select"
-                    handleFollowUp={handleChangeTarget}
-                    modelId={getSlugAsString(router.query.slug) ?? modelId}
-                    applicationProfile={applicationProfile}
-                  />
-                </div>
+                !disableEdit && (
+                  <div
+                    style={{
+                      width: 'max-content',
+                    }}
+                  >
+                    <ClassModal
+                      modalButtonLabel={t('choose-association-target', {
+                        ns: 'admin',
+                      })}
+                      mode="select"
+                      handleFollowUp={handleChangeTarget}
+                      modelId={getSlugAsString(router.query.slug) ?? modelId}
+                      applicationProfile={applicationProfile}
+                    />
+                  </div>
+                )
               }
             >
-              {targetInClassRestriction && (
+              {targetInClassRestriction ? (
                 <NextLink
                   href={`${targetInClassRestriction.uri}${getEnvParam(
                     targetInClassRestriction.uri,
@@ -581,6 +623,8 @@ export default function CommonViewContent({
                     <br />({targetInClassRestriction.curie})
                   </Link>
                 </NextLink>
+              ) : (
+                t('not-defined')
               )}
             </BasicBlock>
             <Separator />


### PR DESCRIPTION
- 'Add code list' option added to the action menu of library class' attributes
- Code lists are selected from the modal (same implementation for adding code list for property shape)
- Added code lists are listed with remove button in attribute's information

<img width="302" alt="Screenshot 2024-06-20 at 9 04 59" src="https://github.com/VRK-YTI/yti-ui/assets/16885816/087ac66e-9f6d-43fe-bcf5-51eb75749553">

Backend: https://github.com/VRK-YTI/yti-datamodel-api/pull/310

Other changes:
- Add check if editing is disabled (=viewing published version) for selecting association's target 
- Show "Not defined" text if no association target has been defined for library class' association