### PR TITLE
YTI-4164 visualization ext references

### DIFF
--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -380,10 +380,11 @@ export default function CommonViewContent({
                       }}
                       key={codeList}
                     >
-                      <Text style={{ marginTop: '5px' }}>
+                      <Text style={{ marginTop: '8px' }}>
                         <Link
                           key={codeList}
                           href={`${codeList}${getEnvParam(codeList, true)}`}
+                          target="_blank"
                         >
                           {codeList.split('/').slice(-2).join(':')}
                         </Link>

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -159,12 +159,17 @@ const GraphContent = ({
 
   const onEdgeClick = useCallback(
     (e, edge) => {
-      if (edge.data.identifier && globalSelected.id !== edge.data.identifier) {
+      const identifier = edge.data.identifier ?? edge.data.origin;
+      if (
+        identifier &&
+        globalSelected.id !== identifier &&
+        globalSelected.modelId + ':' + globalSelected.id !== identifier
+      ) {
         let selectedModelId = modelId;
-        let selectedResourceId = edge.data.identifier;
+        let selectedResourceId = identifier;
         let externalResourceVersion;
 
-        const parts = edge.data.identifier.split(':');
+        const parts = identifier.split(':');
         if (parts.length === 2) {
           selectedModelId = parts[0];
           selectedResourceId = parts[1];

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -376,7 +376,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
         : '';
 
     if (!data.applicationProfile) {
-      return `${label} ${dataType}`;
+      return <div>{`${label} ${dataType}`}</div>;
     } else {
       const codeListsText =
         resource.codeLists && resource.codeLists.length > 0

--- a/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
@@ -36,6 +36,7 @@ export const ClassNodeDiv = styled.div<{
     border-radius: 2px 2px 0px 0px;
     font-weight: 600;
     max-width: 100%;
+    height: 40px;
 
     padding: ${(props) => props.theme.suomifi.spacing.xxs};
 

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -202,20 +202,23 @@ export default function convertToEdges(
         }
 
         if (reference.referenceTarget.startsWith('corner-')) {
+          const sourceIdentifier = [
+            'ATTRIBUTE_DOMAIN',
+            'PARENT_CLASS',
+          ].includes(reference.referenceType)
+            ? node.identifier
+            : reference.identifier;
+
           referenceLabels.push({
             targetId: getEndEdge(reference.referenceTarget),
-            identifier: ['ATTRIBUTE_DOMAIN', 'PARENT_CLASS'].includes(
-              reference.referenceType
-            )
-              ? node.identifier
-              : reference.identifier,
+            identifier: sourceIdentifier,
             label: label,
           });
 
           return createEdge({
             params: getEdgeParams(node.identifier, reference, true),
             isCorner: true,
-            origin: node.identifier,
+            origin: sourceIdentifier,
           });
         }
 
@@ -336,6 +339,15 @@ export default function convertToEdges(
 
     if (index) {
       referenceLabels.splice(index, 1);
+    }
+
+    if (node.referenceTarget.includes(':')) {
+      return createEdge({
+        label: associationInfo.label,
+        identifier: associationInfo.identifier,
+        params: getEdgeParams(nodeIdentifier, node),
+        origin: node.origin,
+      });
     }
 
     return createEdge({

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -317,13 +317,6 @@ export default function convertToEdges(
       });
     }
 
-    if (node.referenceTarget.includes(':')) {
-      return createEdge({
-        params: getEdgeParams(nodeIdentifier, node),
-        origin: node.origin,
-      });
-    }
-
     // remove element from referenceLabels because there might be several references
     // with the same target id. E.g. two associations with the same source (domain) and target (range)
     let associationInfo;

--- a/datamodel-ui/src/modules/graph/utils/get-edge-params/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/get-edge-params/index.ts
@@ -206,7 +206,7 @@ function getPositionAndSize(node: Node, offset?: number) {
   if (offset && offset > 0) {
     return {
       x: node.position.x + 5,
-      // 65 here is the height of the classNode title + gap
+      // 65 here is the height of the classNode title
       // Multiplier 37.25 is gap (5px) + margin (2 * 2px) + border (0.625px) + height (27px)
       y: node.position.y + 65 + (offset - 1) * 37.25,
       w: node.width ? node.width - 10 : 0,

--- a/datamodel-ui/src/modules/graph/utils/get-edge-params/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/get-edge-params/index.ts
@@ -206,10 +206,11 @@ function getPositionAndSize(node: Node, offset?: number) {
   if (offset && offset > 0) {
     return {
       x: node.position.x + 5,
-      // 60 here is the height of the classNode title
-      y: node.position.y + 5 + 60 + (offset - 1) * 38,
+      // 65 here is the height of the classNode title + gap
+      // Multiplier 37.25 is gap (5px) + margin (2 * 2px) + border (0.625px) + height (27px)
+      y: node.position.y + 65 + (offset - 1) * 37.25,
       w: node.width ? node.width - 10 : 0,
-      h: 30,
+      h: 27,
     };
   }
 

--- a/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
@@ -361,7 +361,7 @@ export const expectedLibraryEdges = {
         width: 20,
         color: '#212121',
       },
-      data: { origin: 'is-spouse' },
+      data: { origin: 'is-spouse', identifier: 'is-spouse' },
     },
     {
       source: '#corner-3',

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -93,6 +93,10 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
             version={version}
             applicationProfile={modelInfo?.type === 'PROFILE'}
             organizationIds={organizationIds}
+            namespaces={[
+              ...modelInfo.internalNamespaces,
+              ...modelInfo.externalNamespaces,
+            ]}
           >
             <ModelTools
               modelId={modelId}
@@ -221,6 +225,10 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
           applicationProfile={modelInfo?.type === 'PROFILE'}
           organizationIds={organizationIds}
           drawer={<Drawer views={views} />}
+          namespaces={[
+            ...(modelInfo?.internalNamespaces ?? []),
+            ...(modelInfo?.externalNamespaces ?? []),
+          ]}
         >
           <ModelTools
             modelId={modelId}


### PR DESCRIPTION
Visualization changes:
- Fix fetching external resource after selected from the visualization
- Wrap node title to div. This fixes issue YTI-4165
- Add origin to all edges, so the correct resource will be selected when clicking edge, even if there are corners between source and target
- Fix calculating starting point of the association edge. Change multiplier to 37.25 because borders don't increase the height of the node 2px but 1.25px. Set also height for node title, so it will be the same in both edit and view mode (in edit mode there is a button in top right corner, which increases the height of the element)

Other fixes
- Adjust codelist text margin and open link to new tab 