### PR TITLE
YTI-4211 fix redirection after model creation

### DIFF
--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -205,7 +205,17 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
   useEffect(() => {
     if (router.query.new) {
       dispatch(setNotification('MODEL_ADD'));
-      router.replace(`/model/${modelId}`, undefined, { shallow: true });
+      // preserve all query parameters except "new" and replace it with "draft"
+      const { ['new']: newKey, ...query } = router.query;
+      query['draft'] = newKey;
+      router.replace(
+        {
+          pathname: router.pathname,
+          query: query,
+        },
+        undefined,
+        { shallow: true }
+      );
     }
   }, [router, dispatch, modelId]);
 


### PR DESCRIPTION
Previously, if the model page had a "new" query parameter, the module would use router to replace the url to not include it.

This breaks things, since new models are drafts, but urls without "new" or "draft" are considered non-drafts.

To fix this, the url replacement still remains, but now changes the "new" parameter to "draft".
