### PR TITLE
YTI-4210 Handle external resources' properties

### DIFF
--- a/datamodel-ui/src/common/components/class/class.slice.tsx
+++ b/datamodel-ui/src/common/components/class/class.slice.tsx
@@ -10,6 +10,7 @@ import {
 import { InternalClassInfo } from '@app/common/interfaces/internal-class.interface';
 import { pathForModelType } from '@app/common/utils/api-utils';
 import { convertToPayload } from './utils';
+import { ExternalClassType } from '@app/common/interfaces/external-class.interface';
 
 interface ClassData {
   modelId: string;
@@ -221,6 +222,20 @@ export const classApi = createApi({
       }),
       invalidatesTags: ['Class'],
     }),
+    getExternalClass: builder.query<
+      ExternalClassType,
+      {
+        uri: string;
+      }
+    >({
+      query: (value) => ({
+        url: '/class/external',
+        params: {
+          uri: value.uri,
+        },
+        method: 'GET',
+      }),
+    }),
   }),
 });
 
@@ -262,6 +277,7 @@ export const {
   useUpdateClassResrictionTargetMutation,
   useAddCodeListMutation,
   useRemoveCodeListMutation,
+  useGetExternalClassQuery,
   util: { getRunningQueriesThunk },
 } = classApi;
 

--- a/datamodel-ui/src/common/interfaces/external-class.interface.ts
+++ b/datamodel-ui/src/common/interfaces/external-class.interface.ts
@@ -1,0 +1,14 @@
+export interface ExternalClassType {
+  uri: string;
+  label: { [key: string]: string };
+  description?: { [key: string]: string };
+  attributes?: {
+    label: { [key: string]: string };
+    description?: { [key: string]: string };
+    uri: string;
+  }[];
+  associations?: {
+    label: { [key: string]: string };
+    uri: string;
+  }[];
+}

--- a/datamodel-ui/src/modules/class-view/application-profile-flow.tsx
+++ b/datamodel-ui/src/modules/class-view/application-profile-flow.tsx
@@ -5,7 +5,10 @@ import {
   InternalClass,
   InternalClassInfo,
 } from '@app/common/interfaces/internal-class.interface';
-import { getPrefixFromURI } from '@app/common/utils/get-value';
+import {
+  SUOMI_FI_NAMESPACE,
+  getPrefixFromURI,
+} from '@app/common/utils/get-value';
 import { SimpleResource } from '@app/common/interfaces/simple-resource.interface';
 
 export default function ApplicationProfileFlow({
@@ -96,6 +99,11 @@ export default function ApplicationProfileFlow({
             version: selectedTargetClass.targetClass.dataModelInfo.version,
             classId: selectedTargetClass.targetClass.identifier,
             isAppProfile: selectedTargetClass.isAppProfile ?? false,
+            externalId: !selectedTargetClass.targetClass.id.startsWith(
+              SUOMI_FI_NAMESPACE
+            )
+              ? selectedTargetClass.targetClass.id
+              : undefined,
           }}
           handleFollowUp={(value?: {
             associations: SimpleResource[];

--- a/datamodel-ui/src/modules/resource-picker-modal/util.tsx
+++ b/datamodel-ui/src/modules/resource-picker-modal/util.tsx
@@ -40,3 +40,35 @@ export function convertSimpleResourceToResultType(
     }),
   }));
 }
+
+export function convertExternalResourceToResultType(
+  resources: {
+    label: {
+      [key: string]: string;
+    };
+    description?: {
+      [key: string]: string;
+    };
+    uri: string;
+  }[],
+  lang: string
+): ResultType[] {
+  return resources.map((data) => {
+    return {
+      target: {
+        identifier: data.uri,
+        label: `${getLanguageVersion({
+          data: data.label,
+          lang: lang,
+        })}`,
+        linkLabel: data.uri,
+        link: data.uri,
+        note: `${getLanguageVersion({
+          data: data.description,
+          lang: lang,
+        })}`,
+        status: 'VALID',
+      },
+    };
+  });
+}

--- a/datamodel-ui/src/store/tag-invalidator-middleware.ts
+++ b/datamodel-ui/src/store/tag-invalidator-middleware.ts
@@ -61,7 +61,6 @@ tagInvalidatorMiddleware.startListening({
     return (
       mutationIsFulfilled(action) &&
       [
-        'createClass',
         'createResource',
         'renameClass',
         'renameResource',
@@ -79,6 +78,26 @@ tagInvalidatorMiddleware.startListening({
     );
     listenerApi.dispatch(
       searchInternalResourcesApi.util.invalidateTags([
+        { type: 'InternalResources', id: 'ALL' },
+      ])
+    );
+  },
+});
+
+// While creating node shape, new attributes and associations might be created as well, so they should be invalidated also.
+tagInvalidatorMiddleware.startListening({
+  predicate: (action) => {
+    return (
+      mutationIsFulfilled(action) &&
+      'createClass' === action.meta?.arg?.endpointName
+    );
+  },
+  effect: async (action, listenerApi) => {
+    listenerApi.dispatch(
+      searchInternalResourcesApi.util.invalidateTags([
+        { type: 'InternalResources', id: 'CLASS' },
+        { type: 'InternalResources', id: 'ATTRIBUTE' },
+        { type: 'InternalResources', id: 'ASSOCIATION' },
         { type: 'InternalResources', id: 'ALL' },
       ])
     );


### PR DESCRIPTION
- Use `getExternalClass` endpoint if selected class is not Interoperability platform class
- Map external resource data as a `SimpleResource`
- Fixed tag invalidation when creating node shape. Also attribute and association lists must be invalidated because new properties might be created during creating new node shape.