### PR TITLE
YTI-3863 fix for resource being saved to a wrong datamodel

### DIFF
--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -192,6 +192,7 @@ export default function ResourceView({
   };
 
   const handleFollowUp = (value?: UriData) => {
+    dispatch(resetSelected());
     dispatch(initializeResource(type, value, applicationProfile));
 
     setView(


### PR DESCRIPTION
Browsing to an attribute/association would store the modelId in the "active" state, which would then be be considered the current modelId when creating a new attribute/association.

This means saving the new attribute/association was being done to whatever modelId was previously set in state.

This fix will reset the active state when browsing to the attribute/association create form, and the resource should now be saved to the proper datamodel.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/11126f6d-8f3f-4e0a-8ab1-3b593f087014">
