### PR TITLE
Workaround for broken expanders on Chrome 129+ and Edge 129+

### DIFF
--- a/datamodel-ui/styles/globals.scss
+++ b/datamodel-ui/styles/globals.scss
@@ -15,3 +15,9 @@ body {
     z-index: 2;
   }
 }
+
+// Workaround for broken expanders on Chrome 129+ and Edge 129+
+// Will be fixed by upgrading to suomifi-ui-components 14.0.1
+.fi-expander_content {
+  animation: unset !important;
+}

--- a/terminology-ui/styles/globals.scss
+++ b/terminology-ui/styles/globals.scss
@@ -7,3 +7,9 @@ body {
   @include fi-text-body-text;
   background-color: $fi-color-depth-light3;
 }
+
+// Workaround for broken expanders on Chrome 129+ and Edge 129+
+// Will be fixed by upgrading to suomifi-ui-components 14.0.1
+.fi-expander_content {
+  animation: unset !important;
+}


### PR DESCRIPTION
This is fixed in suomifi-ui-components 14.0.1, but for now we'll just add a quick workaround.
