### PR TITLE
YTI-4235 Node shape's target class

### DIFF
--- a/datamodel-ui/src/common/components/class/utils.ts
+++ b/datamodel-ui/src/common/components/class/utils.ts
@@ -40,8 +40,12 @@ export function convertToPayload(
     ...(applicationProfile &&
       !basedOnNodeShape && {
         properties: [
-          ...(data.association?.map((a) => a.uri) ?? []),
-          ...(data.attribute?.map((a) => a.uri) ?? []),
+          ...(data.association?.map((a) =>
+            a.versionIri ? a.versionIri + a.identifier : a.uri
+          ) ?? []),
+          ...(data.attribute?.map((a) =>
+            a.versionIri ? a.versionIri + a.identifier : a.uri
+          ) ?? []),
         ],
       }),
   };

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -51,7 +51,10 @@ import {
 } from '@app/common/components/model/model.slice';
 import ResourcePicker from '../resource-picker-modal';
 import { SimpleResource } from '@app/common/interfaces/simple-resource.interface';
-import { getPrefixFromURI } from '@app/common/utils/get-value';
+import {
+  getPrefixFromURI,
+  SUOMI_FI_NAMESPACE,
+} from '@app/common/utils/get-value';
 import { setNotification } from '@app/common/components/notifications/notifications.slice';
 import {
   IDENTIFIER_MAX,
@@ -629,6 +632,11 @@ export default function ClassForm({
                 classId: selectedTargetClass.identifier,
                 version: selectedTargetClass.version,
                 isAppProfile: false,
+                externalId: !selectedTargetClass.classInfo.uri.startsWith(
+                  SUOMI_FI_NAMESPACE
+                )
+                  ? selectedTargetClass.classInfo.uri
+                  : undefined,
               }}
               handleFollowUp={handleResourceUpdate}
             />


### PR DESCRIPTION
Fixes for setting target class for node shape
- use versionIRI in properties if available (currently uses always draft version IRI)
- add external id, to indicate that we are adding reference to external resource