### PR TITLE
YTI-4250 Delete versioned models

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -178,9 +178,11 @@
     "deleting-attribute": "Removing attribute",
     "deleting-class": "Removing class",
     "deleting-model": "Removing model",
+    "model-delete-disabled": "Cannot remove the model, because there are references to it.",
     "model-description": "Remove model {{targetName}}",
     "model-description-version": "Remove version {{targetVersion}} from model {{targetName}}?",
     "model-error": "An error occurrred while removing model {{targetName}}",
+    "model-in-use": "There are references to the model in following models which means, that these references remain without a target. Do you still want to delete the model?",
     "model-success": "Model {{targetName}} removed",
     "model-title": "Remove model"
   },

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -178,9 +178,11 @@
     "deleting-attribute": "Poistetaan attribuuttia",
     "deleting-class": "Poistetaan luokkaa",
     "deleting-model": "Poistetaan tietomallia",
+    "model-delete-disabled": "Tietomallia ei voi poistaa, koska siihen on viittauksia.",
     "model-description": "Haluatko poistaa tietomallin {{targetName}}?",
     "model-description-version": "Haluatko poistaa version {{targetVersion}} tietomallista {{targetName}}?",
     "model-error": "Tietomallin {{targetName}} poistamisessa ilmeni ongelma",
+    "model-in-use": "Tietomalliin on viittauksia eli se on käytössä seuraavissa malleissa, joiden viittaukset jäävät ilman kohdettaan. Poistetaanko silti?",
     "model-success": "Tietomalli {{targetName}} poistettu",
     "model-title": "Poista tietomalli"
   },

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -175,8 +175,10 @@
     "deleting-attribute": "",
     "deleting-class": "",
     "deleting-model": "",
+    "model-delete-disabled": "",
     "model-description": "",
     "model-description-version": "",
+    "model-in-use": "",
     "model-error": "",
     "model-success": "",
     "model-title": ""

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -166,6 +166,21 @@ export const modelApi = createApi({
         method: 'POST',
       }),
     }),
+    modelReferrers: builder.query<
+      string[],
+      {
+        modelId: string;
+        version?: string;
+      }
+    >({
+      query: (value) => ({
+        url: `/model/${value.modelId}/referrers`,
+        params: {
+          version: value.version,
+        },
+        method: 'GET',
+      }),
+    }),
   }),
 });
 
@@ -182,6 +197,7 @@ export const {
   useSubscribeMutation,
   useUnsubscribeMutation,
   useCopyModelMutation,
+  useModelReferrersQuery,
   util: { getRunningQueriesThunk },
 } = modelApi;
 

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -88,6 +88,10 @@ export default function ModelInfoView({
     actions: ['EDIT_DATA_MODEL'],
     targetOrganization: organizationIds,
   });
+  const hasAdminPermission = HasPermission({
+    actions: ['ADMIN_DATA_MODEL'],
+    targetOrganization: organizationIds,
+  });
   const { data: modelInfo } = useGetModelQuery({
     modelId: modelId,
     version: version,
@@ -257,7 +261,8 @@ export default function ModelInfoView({
             ) : (
               <></>
             )}
-            {hasPermission && (user.superuser || !modelInfo.version) ? (
+            {hasAdminPermission &&
+            (user.superuser || modelInfo.status !== 'VALID') ? (
               <ActionMenuItem onClick={() => handleModalChange('delete', true)}>
                 {t('remove', { ns: 'admin' })}
               </ActionMenuItem>
@@ -475,6 +480,7 @@ export default function ModelInfoView({
                   type="model"
                   visible={openModals.delete}
                   hide={() => handleModalChange('delete', false)}
+                  status={modelInfo.status}
                 />
                 {!version && (
                   <CreateReleaseModal


### PR DESCRIPTION
Allow deleting versioned data models for admin users. 

Deleting is denied, if status is `retired` or `superseded` and there are references to the model being deleted.
<img width="602" alt="tietomalli-poisto-estetty" src="https://github.com/user-attachments/assets/ad73bbba-a41e-4f19-96a2-715e9539f699">

Otherwise, the list of referrer models is shown but delete button is enabled
<img width="605" alt="Screenshot 2024-11-21 at 7 32 15" src="https://github.com/user-attachments/assets/aeeb83d0-74ef-4c93-b9bd-16e08701aa55">

For data models with status `valid`, delete option is not visible in the action menu.
