### PR TITLE
YTI-4289 terminology export

### DIFF
--- a/terminology-ui/public/locales/en/common.json
+++ b/terminology-ui/public/locales/en/common.json
@@ -221,7 +221,7 @@
   "vocabulary-info-terminology": "Terminology information and actions",
   "vocabulary-info-vocabulary-button": "Download terminology",
   "vocabulary-info-vocabulary-export": "Download terminology as a file",
-  "vocabulary-info-vocabulary-export-description": "You can inspect glossary, concept selection, and concept information in Excel file formats.",
+  "vocabulary-info-vocabulary-export-description": "You can inspect glossary, concept collection, and concept information in different file formats.",
   "vocabulary-info-vocabulary-type": "Vocabulary type",
   "vocabulary-results-collections_one": "Collections {{count}} item with following filters",
   "vocabulary-results-collections_other": "Collections {{count}} items with following filters",

--- a/terminology-ui/public/locales/fi/common.json
+++ b/terminology-ui/public/locales/fi/common.json
@@ -221,7 +221,7 @@
   "vocabulary-info-terminology": "Sanaston tiedot ja toiminnot",
   "vocabulary-info-vocabulary-button": "Tallenna sanasto",
   "vocabulary-info-vocabulary-export": "Tallenna sanasto tiedostona",
-  "vocabulary-info-vocabulary-export-description": "Voit tarkastella sanaston, käsitevalikoiman ja käsitteen, sekä termien tietoja Excel-tiedostomuodoissa.",
+  "vocabulary-info-vocabulary-export-description": "Voit tarkastella sanaston, käsitekokoelman ja käsitteen, sekä termien tietoja eri tiedostomuodoissa.",
   "vocabulary-info-vocabulary-type": "Sanastotyyppi",
   "vocabulary-results-collections_one": "Käsitekokoelmia {{count}} kpl seuraavilla rajauksilla",
   "vocabulary-results-collections_other": "Käsitekokoelmia {{count}} kpl seuraavilla rajauksilla",

--- a/terminology-ui/public/locales/sv/common.json
+++ b/terminology-ui/public/locales/sv/common.json
@@ -221,7 +221,7 @@
   "vocabulary-info-terminology": "Ordlistans uppgifter och funktioner",
   "vocabulary-info-vocabulary-button": "Spara ordlistan",
   "vocabulary-info-vocabulary-export": "Spara ordlistan som en fil",
-  "vocabulary-info-vocabulary-export-description": "\"Du kan granska uppgifter om en ordlista,",
+  "vocabulary-info-vocabulary-export-description": "Du kan granska uppgifter om en ordlista,",
   "vocabulary-info-vocabulary-type": "Ordlistans typ",
   "vocabulary-results-collections_one": "Begreppsurval hittades {{count}} st. med följande begränsningar",
   "vocabulary-results-collections_other": "Begreppsurval hittades {{count}} st. med följande begränsningar",

--- a/terminology-ui/src/common/components/as-file-modal/as-file-modal.styles.tsx
+++ b/terminology-ui/src/common/components/as-file-modal/as-file-modal.styles.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import { Modal, ModalContent, RadioButtonGroup } from 'suomifi-ui-components';
+
+export const ButtonFooter = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: ${(props) => props.theme.suomifi.spacing.l};
+  gap: ${(props) => props.theme.suomifi.spacing.m};
+`;
+
+export const NarrowModal = styled(Modal)`
+  ${(props) =>
+    props.variant !== 'smallScreen' && 'max-width: 600px !important'};
+`;
+
+export const RadioButtonGroupSimple = styled(RadioButtonGroup)`
+  margin-top: ${(props) => props.theme.suomifi.spacing.xs};
+
+  .fi-radio-button-group_legend {
+    display: none;
+  }
+`;
+
+export const SimpleModalContent = styled(ModalContent)`
+  padding: 24px 30px !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;

--- a/terminology-ui/src/common/components/as-file-modal/index.tsx
+++ b/terminology-ui/src/common/components/as-file-modal/index.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from 'next-i18next';
+import Link from 'next/link';
+import { useState } from 'react';
+import {
+  Link as SuomiLink,
+  Button,
+  ModalTitle,
+  RadioButton,
+  Text,
+} from 'suomifi-ui-components';
+import { useBreakpoints } from 'yti-common-ui/media-query';
+import {
+  ButtonFooter,
+  NarrowModal,
+  RadioButtonGroupSimple,
+  SimpleModalContent,
+} from './as-file-modal.styles';
+
+interface AsFileModalProps {
+  prefix: string;
+  visible: boolean;
+  onClose: () => void;
+  filename?: string;
+}
+
+export default function AsFileModal({
+  prefix,
+  visible,
+  onClose,
+  filename,
+}: AsFileModalProps) {
+  const { t, i18n } = useTranslation('common');
+  const { isSmall } = useBreakpoints();
+  const fileTypes = ['JSON-LD', 'RDF', 'Turtle'];
+
+  const [chosenFileType, setChosenFileType] = useState('JSON-LD');
+
+  const handleClose = () => {
+    onClose();
+    setChosenFileType('JSON-LD');
+  };
+
+  return (
+    <>
+      <NarrowModal
+        appElementId="__next"
+        visible={visible}
+        variant={isSmall ? 'smallScreen' : 'default'}
+        onEscKeyDown={() => onClose()}
+      >
+        <SimpleModalContent>
+          <div>
+            <ModalTitle>{t('vocabulary-info-vocabulary-export')}</ModalTitle>
+            <Text variant="bold">
+              {t('vocabulary-info-vocabulary-export-description')}
+            </Text>
+            <RadioButtonGroupSimple
+              labelText=""
+              name="file-types-radio-button-group"
+              defaultValue="JSON-LD"
+              onChange={setChosenFileType}
+            >
+              {fileTypes.map((type) => (
+                <RadioButton
+                  key={`file-type-radio-button-${type}`}
+                  value={type}
+                >
+                  {type}
+                </RadioButton>
+              ))}
+            </RadioButtonGroupSimple>
+          </div>
+
+          <ButtonFooter>
+            <Link
+              href={`/api/getTerminologyAsFile?prefix=${prefix}&fileType=${chosenFileType}&filename=${filename}`}
+              passHref
+              legacyBehavior
+            >
+              <SuomiLink href="">
+                <Button id="download-button" onClick={handleClose}>
+                  {t('vocabulary-info-vocabulary-button')}
+                </Button>
+              </SuomiLink>
+            </Link>
+            <Button
+              variant="secondary"
+              onClick={() => handleClose()}
+              id="cancel-button"
+            >
+              {t('site-cancel')}
+            </Button>
+          </ButtonFooter>
+        </SimpleModalContent>
+      </NarrowModal>
+    </>
+  );
+}

--- a/terminology-ui/src/common/components/info-dropdown/info-expander.test.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.test.tsx
@@ -68,6 +68,12 @@ const data = {
 } as TerminologyInfo;
 
 describe('infoExpander', () => {
+  beforeEach(() => {
+    const appRoot = document.createElement('div');
+    appRoot.setAttribute('id', '__next');
+    document.body.appendChild(appRoot);
+  });
+
   it('should render subscribe button', async () => {
     const loginInitialState = Object.assign({}, initialState);
     loginInitialState['anonymous'] = false;

--- a/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
@@ -5,6 +5,7 @@ import {
   ExpanderContent,
   ExpanderTitleButton,
   ExternalLink,
+  IconDownload,
   IconEdit,
   IconPlus,
   VisuallyHidden,
@@ -43,11 +44,13 @@ import {
 } from '@app/common/interfaces/interfaces-v2';
 import { getLanguageVersion } from 'yti-common-ui/utils/get-language-version';
 import { compareLocales } from 'yti-common-ui/utils/compare-locales';
+import { useState } from 'react';
 
 const Subscription = dynamic(
   () => import('@app/common/components/subscription/subscription')
 );
 const CopyTerminologyModal = dynamic(() => import('../copy-terminology-modal'));
+const AsFileModal = dynamic(() => import('../as-file-modal'));
 
 interface InfoExpanderProps {
   data?: TerminologyInfo;
@@ -60,6 +63,7 @@ export default function InfoExpander({
 }: InfoExpanderProps) {
   const { t, i18n } = useTranslation('common');
   const { urlState } = useUrlState();
+  const [showDownloadFileModal, setShowDownloadFileModal] = useState(false);
   const router = useRouter();
   const user = useSelector(selectLogin());
   const terminologyId = data?.prefix ?? '';
@@ -72,6 +76,10 @@ export default function InfoExpander({
   if (!data) {
     return null;
   }
+
+  const handleDownloadClick = () => {
+    setShowDownloadFileModal(true);
+  };
 
   return (
     <InfoExpanderWrapper id="info-expander">
@@ -230,6 +238,35 @@ export default function InfoExpander({
         )}
 
         <Separator isLarge />
+
+        <BasicBlock
+          title={t('vocabulary-info-vocabulary-export')}
+          extra={
+            <BasicBlockExtraWrapper>
+              <Button
+                icon={<IconDownload />}
+                variant="secondary"
+                onClick={() => handleDownloadClick()}
+                id="export-terminology-button"
+              >
+                {t('vocabulary-info-vocabulary-button')}
+              </Button>
+            </BasicBlockExtraWrapper>
+          }
+          id="export-terminology-block"
+        >
+          {t('vocabulary-info-vocabulary-export-description')}
+        </BasicBlock>
+
+        <AsFileModal
+          prefix={terminologyId}
+          visible={showDownloadFileModal}
+          onClose={() => setShowDownloadFileModal(false)}
+          filename={getLanguageVersion({
+            data: data.label,
+            lang: i18n.language,
+          })}
+        />
 
         {!user.anonymous && (
           <>

--- a/terminology-ui/src/pages/api/getTerminologyAsFile.ts
+++ b/terminology-ui/src/pages/api/getTerminologyAsFile.ts
@@ -1,0 +1,78 @@
+import { userCookieOptions } from '@app/common/utils/user-cookie-options';
+import axios, { RawAxiosRequestHeaders } from 'axios';
+import { withIronSessionApiRoute } from 'iron-session/next';
+
+export default withIronSessionApiRoute(
+  async function getModelAsFile(req, res) {
+    const prefix = (req.query['prefix'] as string) ?? '';
+    const fileType = (req.query['fileType'] as string) ?? 'LD+JSON';
+    let filename = (req.query['filename'] as string) ?? 'terminology';
+
+    let mimeType: string;
+    switch (fileType) {
+      case 'RDF':
+        mimeType = 'application/rdf+xml';
+        filename += '.rdf';
+        break;
+      case 'Turtle':
+        mimeType = 'text/turtle';
+        filename += '.ttl';
+        break;
+      case 'LD+JSON':
+      default:
+        mimeType = 'application/ld+json';
+        filename += '.jsonld';
+    }
+
+    const headers: RawAxiosRequestHeaders = {
+      Accept: mimeType,
+    };
+
+    const forwardedFor = req.headers['x-forwarded-for'] as string;
+    if (forwardedFor) {
+      headers['x-forwarded-for'] = forwardedFor;
+    }
+    const host = req.headers['host'] as string;
+    if (host) {
+      headers['host'] = host;
+    }
+
+    const sessionCookies = req.session.cookies ?? {};
+
+    const cookieString = Object.entries(sessionCookies)
+      .map(([key, value]) => {
+        if (key.toLowerCase() === 'jsessionid') {
+          return `JSESSIONID=${value}`;
+        } else if (key.toLowerCase().startsWith('_shibsession')) {
+          return `${key}=${value}`;
+        }
+      })
+      .filter(Boolean)
+      .join('; ');
+
+    headers['Cookie'] = cookieString;
+
+    const apiUrl =
+      process.env.AWS_ENV === 'local'
+        ? process.env.TERMINOLOGY_API_URL
+        : `${process.env.AUTH_PROXY_URL}/terminolgoy-api`;
+
+    const { status, data: response } = await axios.get(
+      `${apiUrl}/export/${prefix}`,
+      {
+        headers: headers,
+        responseType: 'stream',
+        decompress: false,
+      }
+    );
+
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    res.status(status);
+    response.pipe(res);
+  },
+  {
+    ...userCookieOptions,
+  }
+);


### PR DESCRIPTION
Add modal for selecting file format (json-ld, rdf or turtle) for export. Modal styles copied from datamodel application. In terminology, it's only possible to download file (no viewing in browser like in datamodel app). 