### PR TITLE
YTI-4291 Fix subscription links

### DIFF
--- a/terminology-ui/src/modules/own-information/subscription-block.tsx
+++ b/terminology-ui/src/modules/own-information/subscription-block.tsx
@@ -87,11 +87,7 @@ export default function SubscriptionBlock({
           {subscriptions?.resources.map((resource, idx) => {
             return (
               <SubscriptionsListItem key={`subscription-list-item-${idx}`}>
-                <Link
-                  passHref
-                  href={`/terminology-api/api/v1/resolve?uri=${resource.uri}`}
-                  legacyBehavior
-                >
+                <Link passHref href={resource.uri} legacyBehavior>
                   <SuomiLink href="">
                     {resource.prefLabel
                       ? getLanguageVersion({


### PR DESCRIPTION
Use resource's URI, e.g. https://iri.suomi.fi/terminology/test/, as an href value.