### PR TITLE
small fix for concept collections pagination

### DIFF
--- a/terminology-ui/src/modules/vocabulary/index.tsx
+++ b/terminology-ui/src/modules/vocabulary/index.tsx
@@ -434,7 +434,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
               },
             }}
           />
-          <Pagination maxPages={filteredCollections.length / 50} />
+          <Pagination maxPages={Math.ceil(filteredCollections.length / 50)} />
         </>
       );
     }


### PR DESCRIPTION
This change should properly show the max page number at the bottom, e.g. `1/5`.
