### PR TITLE
add cache invalidation tag for model slice

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -65,6 +65,7 @@ export const modelApi = createApi({
         }`,
         method: 'DELETE',
       }),
+      invalidatesTags: ['Model'],
     }),
     createRelease: builder.mutation<
       string,


### PR DESCRIPTION
This should fix an issue where attempting to create a new draft model would fail after having removed the previous draft.

YTI-4307