### PR TITLE
correctly increase max length for documentation textarea

### DIFF
--- a/common-ui/components/form/language-selector.tsx
+++ b/common-ui/components/form/language-selector.tsx
@@ -14,8 +14,6 @@ import {
 import { TEXT_AREA_MAX, TEXT_INPUT_MAX } from '../../utils/constants';
 import { compareLocales } from '../../utils/compare-locales';
 
-const DOCUMENTATION_TEXT_AREA_MAX = 50000;
-
 export interface LanguageBlockType {
   labelText: string;
   uniqueItemId: string;
@@ -159,7 +157,7 @@ export default function LanguageSelector(
             }
             defaultValue={item.description}
             id={`description-input-${item.uniqueItemId}`}
-            maxLength={DOCUMENTATION_TEXT_AREA_MAX}
+            maxLength={TEXT_INPUT_MAX}
           />
         </LanguageBlock>
       ))}

--- a/datamodel-ui/src/modules/documentation/index.tsx
+++ b/datamodel-ui/src/modules/documentation/index.tsx
@@ -68,6 +68,8 @@ import { useBreakpoints } from 'yti-common-ui/media-query';
 import { isDraftModel } from '../model';
 import { useRouter } from 'next/router';
 
+const DOCUMENTATION_TEXT_AREA_MAX = 50000;
+
 export default function Documentation({
   modelId,
   version,
@@ -643,7 +645,7 @@ export default function Documentation({
               }
               onKeyDown={(e) => e.key === 'Enter' && handleEnterClick(e)}
               id="documentation-textarea"
-              maxLength={TEXT_AREA_MAX}
+              maxLength={DOCUMENTATION_TEXT_AREA_MAX}
             />
           </div>
 


### PR DESCRIPTION
Previous fix (#772) was done in the wrong place, this should be correct.
