### PR TITLE
disable unsupported pagination for collections

### DIFF
--- a/terminology-ui/src/modules/vocabulary/index.tsx
+++ b/terminology-ui/src/modules/vocabulary/index.tsx
@@ -434,7 +434,6 @@ export default function Vocabulary({ id }: VocabularyProps) {
               },
             }}
           />
-          <Pagination maxPages={Math.ceil(filteredCollections.length / 50)} />
         </>
       );
     }


### PR DESCRIPTION
Since pagination isn't supported by the backend, let's disable it for now.

This could be properly implemented later in frontend or backend.